### PR TITLE
feat: implement NOT removal mutation with CursorApplier interface

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/spf13/cobra v1.8.0
 	golang.org/x/text v0.27.0
+	golang.org/x/tools v0.34.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -10,5 +10,7 @@ github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 golang.org/x/text v0.27.0 h1:4fGWRpyh641NLlecmyl4LOe6yDdfaYNrGb2zdfo4JV4=
 golang.org/x/text v0.27.0/go.mod h1:1D28KMCvyooCX9hBiosv5Tz/+YLxj0j7XhWjpSUF7CU=
+golang.org/x/tools v0.34.0 h1:qIpSLOxeCYGg9TrcJokLBG4KFA6d795g0xkBkiESGlo=
+golang.org/x/tools v0.34.0/go.mod h1:pAP9OwEaY1CAW3HOmg3hLZC5Z0CCmzjAF2UQMSqNARg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/execution/overlay.go
+++ b/internal/execution/overlay.go
@@ -11,6 +11,8 @@ import (
 	"path/filepath"
 	"time"
 
+	"golang.org/x/tools/go/ast/astutil"
+
 	"github.com/sivchari/gomu/internal/mutation"
 )
 
@@ -110,13 +112,11 @@ func (om *OverlayMutator) Cleanup() error {
 
 // createMutatedFile creates a mutated version of the source file.
 func (om *OverlayMutator) createMutatedFile(mutant mutation.Mutant, originalPath, mutatedPath string) error {
-	// Read original source
 	src, err := os.ReadFile(originalPath)
 	if err != nil {
 		return fmt.Errorf("failed to read source file: %w", err)
 	}
 
-	// Parse the source file
 	fset := token.NewFileSet()
 
 	file, err := parser.ParseFile(fset, originalPath, src, parser.ParseComments)
@@ -124,17 +124,23 @@ func (om *OverlayMutator) createMutatedFile(mutant mutation.Mutant, originalPath
 		return fmt.Errorf("failed to parse file: %w", err)
 	}
 
-	// Apply mutation
 	mutated := false
 
-	ast.Inspect(file, func(node ast.Node) bool {
-		if node == nil || mutated {
+	astutil.Apply(file, nil, func(c *astutil.Cursor) bool {
+		if mutated {
 			return false
+		}
+
+		node := c.Node()
+		if node == nil {
+			return true
 		}
 
 		pos := fset.Position(node.Pos())
 		if pos.Line == mutant.Line && pos.Column == mutant.Column {
-			mutated = om.applyMutationToNode(node, mutant)
+			mutated = om.applyMutationToNode(node, func(replacement ast.Node) {
+				c.Replace(replacement)
+			}, mutant)
 		}
 
 		return !mutated
@@ -144,11 +150,11 @@ func (om *OverlayMutator) createMutatedFile(mutant mutation.Mutant, originalPath
 		return fmt.Errorf("failed to find mutation target at %s:%d:%d", originalPath, mutant.Line, mutant.Column)
 	}
 
-	// Write mutated code to the new file
 	f, err := os.Create(mutatedPath)
 	if err != nil {
 		return fmt.Errorf("failed to create mutated file: %w", err)
 	}
+
 	defer f.Close()
 
 	if err := format.Node(f, fset, file); err != nil {
@@ -159,14 +165,22 @@ func (om *OverlayMutator) createMutatedFile(mutant mutation.Mutant, originalPath
 }
 
 // applyMutationToNode applies the mutation to a specific AST node.
-func (om *OverlayMutator) applyMutationToNode(node ast.Node, mutant mutation.Mutant) bool {
+func (om *OverlayMutator) applyMutationToNode(node ast.Node, replaceFunc func(ast.Node), mutant mutation.Mutant) bool {
 	engine, err := mutation.New()
 	if err != nil {
 		return false
 	}
 
-	for _, mutatorInterface := range engine.GetMutators() {
-		if mutatorInterface.Apply(node, mutant) {
+	for _, m := range engine.GetMutators() {
+		if ca, ok := m.(mutation.CursorApplier); ok {
+			if ca.ApplyWithCursor(node, replaceFunc, mutant) {
+				return true
+			}
+		}
+	}
+
+	for _, m := range engine.GetMutators() {
+		if m.Apply(node, mutant) {
 			return true
 		}
 	}

--- a/internal/execution/overlay_test.go
+++ b/internal/execution/overlay_test.go
@@ -2,6 +2,7 @@ package execution
 
 import (
 	"encoding/json"
+	"go/ast"
 	"os"
 	"path/filepath"
 	"strings"
@@ -585,7 +586,7 @@ func TestApplyMutationToNodeWithOverlay(t *testing.T) {
 			defer mutator.Cleanup()
 
 			// Use nil node - method checks type anyway
-			result := mutator.applyMutationToNode(nil, mutation.Mutant{
+			result := mutator.applyMutationToNode(nil, func(_ ast.Node) {}, mutation.Mutant{
 				Type:    tt.mutationType,
 				Mutated: "+",
 			})

--- a/internal/mutation/engine.go
+++ b/internal/mutation/engine.go
@@ -75,6 +75,12 @@ type Mutator interface {
 	Apply(node ast.Node, mutant Mutant) bool
 }
 
+// CursorApplier is an optional interface that mutators can implement
+// to support mutations requiring parent node context (e.g., node replacement).
+type CursorApplier interface {
+	ApplyWithCursor(node ast.Node, replaceFunc func(ast.Node), mutant Mutant) bool
+}
+
 // New creates a new mutation engine.
 func New() (*Engine, error) {
 	analyzer, err := analysis.New()

--- a/internal/mutation/logical.go
+++ b/internal/mutation/logical.go
@@ -7,8 +7,9 @@ import (
 )
 
 const (
-	logicalMutatorName = "logical"
-	logicalBinaryType  = "logical_binary"
+	logicalMutatorName    = "logical"
+	logicalBinaryType     = "logical_binary"
+	logicalNotRemovalType = "logical_not_removal"
 )
 
 // LogicalMutator mutates logical operators.
@@ -26,6 +27,10 @@ func (m *LogicalMutator) CanMutate(node ast.Node) bool {
 		return m.isLogicalOp(n.Op)
 	}
 
+	if n, ok := node.(*ast.UnaryExpr); ok {
+		return n.Op == token.NOT
+	}
+
 	return false
 }
 
@@ -37,7 +42,24 @@ func (m *LogicalMutator) Mutate(node ast.Node, fset *token.FileSet) []Mutant {
 		return m.mutateBinaryExpr(n, pos)
 	}
 
+	if n, ok := node.(*ast.UnaryExpr); ok {
+		return m.mutateUnaryExpr(n, pos)
+	}
+
 	return nil
+}
+
+func (m *LogicalMutator) mutateUnaryExpr(expr *ast.UnaryExpr, pos token.Position) []Mutant {
+	return []Mutant{
+		{
+			Line:        pos.Line,
+			Column:      pos.Column,
+			Type:        logicalNotRemovalType,
+			Original:    expr.Op.String(),
+			Mutated:     "",
+			Description: fmt.Sprintf("Remove %s operator", expr.Op.String()),
+		},
+	}
 }
 
 func (m *LogicalMutator) mutateBinaryExpr(expr *ast.BinaryExpr, pos token.Position) []Mutant {
@@ -85,7 +107,28 @@ func (m *LogicalMutator) Apply(node ast.Node, mutant Mutant) bool {
 		return m.applyBinary(node, mutant)
 	}
 
+	if mutant.Type == logicalNotRemovalType {
+		// NOT removal requires node replacement via CursorApplier; not supported here.
+		return false
+	}
+
 	return false
+}
+
+// ApplyWithCursor applies the NOT removal mutation using a replace function for node replacement.
+func (m *LogicalMutator) ApplyWithCursor(node ast.Node, replaceFunc func(ast.Node), mutant Mutant) bool {
+	if mutant.Type != logicalNotRemovalType {
+		return false
+	}
+
+	expr, ok := node.(*ast.UnaryExpr)
+	if !ok || expr.Op != token.NOT {
+		return false
+	}
+
+	replaceFunc(expr.X)
+
+	return true
 }
 
 // applyBinary applies binary operator mutation.

--- a/internal/mutation/logical_test.go
+++ b/internal/mutation/logical_test.go
@@ -196,6 +196,218 @@ func TestLogicalMutator_GetLogicalMutations(t *testing.T) {
 	}
 }
 
+func TestLogicalMutator_Mutate_UnaryExpr(t *testing.T) {
+	t.Parallel()
+
+	mutator := &LogicalMutator{}
+	fset := token.NewFileSet()
+
+	src := "package main\nfunc test() { _ = !a }"
+
+	file, err := parser.ParseFile(fset, "test.go", src, 0)
+	if err != nil {
+		t.Fatalf("Failed to parse file: %v", err)
+	}
+
+	var expr ast.Node
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		if ue, ok := n.(*ast.UnaryExpr); ok {
+			expr = ue
+			return false
+		}
+		return true
+	})
+
+	if expr == nil {
+		t.Fatal("UnaryExpr not found")
+	}
+
+	mutants := mutator.Mutate(expr, fset)
+
+	if len(mutants) != 1 {
+		t.Fatalf("Expected 1 mutant, got %d", len(mutants))
+	}
+
+	m := mutants[0]
+
+	if m.Type != logicalNotRemovalType {
+		t.Errorf("Type = %q, want %q", m.Type, logicalNotRemovalType)
+	}
+
+	if m.Original != "!" {
+		t.Errorf("Original = %q, want %q", m.Original, "!")
+	}
+
+	if m.Mutated != "" {
+		t.Errorf("Mutated = %q, want %q", m.Mutated, "")
+	}
+
+	if m.Line <= 0 {
+		t.Errorf("Expected positive line number, got %d", m.Line)
+	}
+
+	if m.Description == "" {
+		t.Error("Expected non-empty description")
+	}
+}
+
+func TestLogicalMutator_ApplyWithCursor(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		code        string
+		mutantType  string
+		expected    bool
+		wantReplace bool
+	}{
+		{
+			name:        "NOT removal applies and calls replaceFunc",
+			code:        "!a",
+			mutantType:  logicalNotRemovalType,
+			expected:    true,
+			wantReplace: true,
+		},
+		{
+			name:        "non-NOT-removal type returns false",
+			code:        "!a",
+			mutantType:  logicalBinaryType,
+			expected:    false,
+			wantReplace: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mutator := &LogicalMutator{}
+
+			expr, err := parser.ParseExpr(tt.code)
+			if err != nil {
+				t.Fatalf("Failed to parse expression: %v", err)
+			}
+
+			replaced := false
+			replaceFunc := func(ast.Node) {
+				replaced = true
+			}
+
+			mutant := Mutant{
+				Type:     tt.mutantType,
+				Original: "!",
+				Mutated:  "",
+			}
+
+			result := mutator.ApplyWithCursor(expr, replaceFunc, mutant)
+
+			if result != tt.expected {
+				t.Errorf("ApplyWithCursor() = %v, want %v", result, tt.expected)
+			}
+
+			if replaced != tt.wantReplace {
+				t.Errorf("replaceFunc called = %v, want %v", replaced, tt.wantReplace)
+			}
+		})
+	}
+}
+
+func TestLogicalMutator_Apply_NotRemoval(t *testing.T) {
+	t.Parallel()
+
+	mutator := &LogicalMutator{}
+
+	expr, err := parser.ParseExpr("!a")
+	if err != nil {
+		t.Fatalf("Failed to parse expression: %v", err)
+	}
+
+	mutant := Mutant{
+		Type:     logicalNotRemovalType,
+		Original: "!",
+		Mutated:  "",
+	}
+
+	if result := mutator.Apply(expr, mutant); result != false {
+		t.Errorf("Apply() = %v, want false for logicalNotRemovalType", result)
+	}
+}
+
+func TestLogicalMutator_CanMutate_NonNotUnary(t *testing.T) {
+	t.Parallel()
+
+	mutator := &LogicalMutator{}
+
+	expr, err := parser.ParseExpr("-a")
+	if err != nil {
+		t.Fatalf("Failed to parse expression: %v", err)
+	}
+
+	if mutator.CanMutate(expr) {
+		t.Error("CanMutate() = true, want false for unary minus")
+	}
+}
+
+func TestLogicalMutator_Apply_WrongOriginal(t *testing.T) {
+	t.Parallel()
+
+	mutator := &LogicalMutator{}
+	fset := token.NewFileSet()
+
+	src := "package main\nfunc test() { _ = a && b }"
+
+	file, err := parser.ParseFile(fset, "test.go", src, 0)
+	if err != nil {
+		t.Fatalf("Failed to parse file: %v", err)
+	}
+
+	var node ast.Node
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		if be, ok := n.(*ast.BinaryExpr); ok {
+			node = be
+			return false
+		}
+		return true
+	})
+
+	if node == nil {
+		t.Fatal("BinaryExpr not found")
+	}
+
+	mutant := Mutant{
+		Type:     logicalBinaryType,
+		Original: "||",
+		Mutated:  "&&",
+	}
+
+	if result := mutator.Apply(node, mutant); result != false {
+		t.Errorf("Apply() = %v, want false when Original doesn't match node operator", result)
+	}
+}
+
+func TestLogicalMutator_Apply_NonBinaryNode(t *testing.T) {
+	t.Parallel()
+
+	mutator := &LogicalMutator{}
+
+	expr, err := parser.ParseExpr("!a")
+	if err != nil {
+		t.Fatalf("Failed to parse expression: %v", err)
+	}
+
+	mutant := Mutant{
+		Type:     logicalBinaryType,
+		Original: "&&",
+		Mutated:  "||",
+	}
+
+	if result := mutator.Apply(expr, mutant); result != false {
+		t.Errorf("Apply() = %v, want false for non-BinaryExpr node with logicalBinaryType", result)
+	}
+}
+
 func TestLogicalMutator_Apply(t *testing.T) {
 	mutator := &LogicalMutator{}
 	fset := token.NewFileSet()

--- a/internal/mutation/logical_test.go
+++ b/internal/mutation/logical_test.go
@@ -35,7 +35,7 @@ func TestLogicalMutator_CanMutate(t *testing.T) {
 		{
 			name:     "logical not",
 			code:     "!a",
-			expected: false,
+			expected: true,
 		},
 		{
 			name:     "arithmetic addition",

--- a/internal/mutation/logical_test.go
+++ b/internal/mutation/logical_test.go
@@ -214,8 +214,10 @@ func TestLogicalMutator_Mutate_UnaryExpr(t *testing.T) {
 	ast.Inspect(file, func(n ast.Node) bool {
 		if ue, ok := n.(*ast.UnaryExpr); ok {
 			expr = ue
+
 			return false
 		}
+
 		return true
 	})
 
@@ -329,8 +331,8 @@ func TestLogicalMutator_Apply_NotRemoval(t *testing.T) {
 		Mutated:  "",
 	}
 
-	if result := mutator.Apply(expr, mutant); result != false {
-		t.Errorf("Apply() = %v, want false for logicalNotRemovalType", result)
+	if mutator.Apply(expr, mutant) {
+		t.Error("Apply() = true, want false for logicalNotRemovalType")
 	}
 }
 
@@ -367,8 +369,10 @@ func TestLogicalMutator_Apply_WrongOriginal(t *testing.T) {
 	ast.Inspect(file, func(n ast.Node) bool {
 		if be, ok := n.(*ast.BinaryExpr); ok {
 			node = be
+
 			return false
 		}
+
 		return true
 	})
 
@@ -382,8 +386,8 @@ func TestLogicalMutator_Apply_WrongOriginal(t *testing.T) {
 		Mutated:  "&&",
 	}
 
-	if result := mutator.Apply(node, mutant); result != false {
-		t.Errorf("Apply() = %v, want false when Original doesn't match node operator", result)
+	if mutator.Apply(node, mutant) {
+		t.Error("Apply() = true, want false when Original doesn't match node operator")
 	}
 }
 
@@ -403,8 +407,8 @@ func TestLogicalMutator_Apply_NonBinaryNode(t *testing.T) {
 		Mutated:  "||",
 	}
 
-	if result := mutator.Apply(expr, mutant); result != false {
-		t.Errorf("Apply() = %v, want false for non-BinaryExpr node with logicalBinaryType", result)
+	if mutator.Apply(expr, mutant) {
+		t.Error("Apply() = true, want false for non-BinaryExpr node with logicalBinaryType")
 	}
 }
 

--- a/internal/mutation/typecheck.go
+++ b/internal/mutation/typecheck.go
@@ -43,7 +43,8 @@ func (tc *TypeChecker) IsValidMutation(node ast.Node, mutant Mutant) bool {
 	case arithmeticIncDecType,
 		bitwiseBinaryType,
 		bitwiseAssignType,
-		logicalBinaryType:
+		logicalBinaryType,
+		logicalNotRemovalType:
 		return true
 
 	default:


### PR DESCRIPTION
## Summary
- Add `CursorApplier` interface to mutation package for mutations requiring parent node context (node replacement)
- Implement `ApplyWithCursor` on `LogicalMutator` for NOT removal: replaces `!expr` with `expr`
- Switch AST traversal in `overlay.go` from `ast.Inspect` to `astutil.Apply` with `Cursor.Replace()` for parent-aware node replacement
- Add `golang.org/x/tools` dependency for `astutil` package
- Skip type validation for `logical_not_removal` mutants (NOT removal is inherently type-safe)

Closes #15

## Test plan
- [x] All existing tests pass (`go test -race -shuffle=on ./...`)
- [x] `LogicalMutator.CanMutate` returns true for `*ast.UnaryExpr` (NOT)
- [x] `ApplyWithCursor` correctly replaces NOT expression with its operand
- [x] `overlay_test.go` tests updated for new `applyMutationToNode` signature
- [x] Comprehensive NOT removal tests added (Mutate, Apply, ApplyWithCursor, edge cases)
- [x] `go vet ./...` passes