### PR TITLE
feat: add BranchMutator for if-statement condition mutations

### DIFF
--- a/internal/mutation/branch.go
+++ b/internal/mutation/branch.go
@@ -1,0 +1,95 @@
+package mutation
+
+import (
+	"fmt"
+	"go/ast"
+	"go/printer"
+	"go/token"
+	"strings"
+)
+
+const (
+	branchMutatorName   = "branch"
+	branchConditionType = "branch_condition"
+)
+
+// BranchMutator mutates branch conditions in if statements.
+type BranchMutator struct {
+}
+
+// Name returns the name of the mutator.
+func (m *BranchMutator) Name() string {
+	return branchMutatorName
+}
+
+// CanMutate returns true if the node can be mutated by this mutator.
+func (m *BranchMutator) CanMutate(node ast.Node) bool {
+	stmt, ok := node.(*ast.IfStmt)
+	if !ok {
+		return false
+	}
+
+	return !isBoolLiteral(stmt.Cond)
+}
+
+// Mutate generates mutants for the given node.
+func (m *BranchMutator) Mutate(node ast.Node, fset *token.FileSet) []Mutant {
+	stmt, ok := node.(*ast.IfStmt)
+	if !ok {
+		return nil
+	}
+
+	pos := fset.Position(stmt.Cond.Pos())
+	original := exprToString(stmt.Cond)
+
+	return []Mutant{
+		{
+			Line:        pos.Line,
+			Column:      pos.Column,
+			Type:        branchConditionType,
+			Original:    original,
+			Mutated:     boolTrue,
+			Description: fmt.Sprintf("Replace branch condition %q with true", original),
+		},
+		{
+			Line:        pos.Line,
+			Column:      pos.Column,
+			Type:        branchConditionType,
+			Original:    original,
+			Mutated:     boolFalse,
+			Description: fmt.Sprintf("Replace branch condition %q with false", original),
+		},
+	}
+}
+
+// Apply applies the mutation to the given AST node.
+func (m *BranchMutator) Apply(node ast.Node, mutant Mutant) bool {
+	stmt, ok := node.(*ast.IfStmt)
+	if !ok {
+		return false
+	}
+
+	if mutant.Type != branchConditionType {
+		return false
+	}
+
+	stmt.Cond = &ast.Ident{Name: mutant.Mutated}
+
+	return true
+}
+
+// isBoolLiteral reports whether expr is the identifier true or false.
+func isBoolLiteral(expr ast.Expr) bool {
+	ident, ok := expr.(*ast.Ident)
+
+	return ok && (ident.Name == boolTrue || ident.Name == boolFalse)
+}
+
+// exprToString returns a string representation of an AST expression.
+func exprToString(expr ast.Expr) string {
+	var buf strings.Builder
+
+	printer.Fprint(&buf, token.NewFileSet(), expr) //nolint:errcheck
+
+	return buf.String()
+}

--- a/internal/mutation/branch_test.go
+++ b/internal/mutation/branch_test.go
@@ -1,0 +1,267 @@
+package mutation
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+const branchIfSimpleSrc = "package main\nfunc f(x int) bool {\n\tif x > 0 {\n\t\treturn true\n\t}\n\treturn false\n}"
+
+func TestBranchMutator_Name(t *testing.T) {
+	t.Parallel()
+
+	mutator := &BranchMutator{}
+
+	if mutator.Name() != branchMutatorName {
+		t.Errorf("Name() = %q, want %q", mutator.Name(), branchMutatorName)
+	}
+}
+
+func TestBranchMutator_CanMutate(t *testing.T) {
+	t.Parallel()
+
+	mutator := &BranchMutator{}
+
+	tests := []struct {
+		name     string
+		src      string
+		expected bool
+	}{
+		{
+			name:     "if with comparison",
+			src:      branchIfSimpleSrc,
+			expected: true,
+		},
+		{
+			name:     "if with true literal",
+			src:      "package main\nfunc f() {\n\tif true {\n\t}\n}",
+			expected: false,
+		},
+		{
+			name:     "if with false literal",
+			src:      "package main\nfunc f() {\n\tif false {\n\t}\n}",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			fset := token.NewFileSet()
+
+			file, err := parser.ParseFile(fset, "test.go", tt.src, 0)
+			if err != nil {
+				t.Fatalf("Failed to parse file: %v", err)
+			}
+
+			var ifStmt ast.Node
+
+			ast.Inspect(file, func(n ast.Node) bool {
+				if s, ok := n.(*ast.IfStmt); ok {
+					ifStmt = s
+
+					return false
+				}
+
+				return true
+			})
+
+			if ifStmt == nil {
+				t.Fatalf("IfStmt not found in: %s", tt.src)
+			}
+
+			if got := mutator.CanMutate(ifStmt); got != tt.expected {
+				t.Errorf("CanMutate() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestBranchMutator_CanMutate_NonIfNode(t *testing.T) {
+	t.Parallel()
+
+	mutator := &BranchMutator{}
+
+	expr, err := parser.ParseExpr("a && b")
+	if err != nil {
+		t.Fatalf("Failed to parse expression: %v", err)
+	}
+
+	if mutator.CanMutate(expr) {
+		t.Error("CanMutate() = true, want false for non-IfStmt node")
+	}
+}
+
+func TestBranchMutator_Mutate(t *testing.T) {
+	t.Parallel()
+
+	mutator := &BranchMutator{}
+	fset := token.NewFileSet()
+
+	file, err := parser.ParseFile(fset, "test.go", branchIfSimpleSrc, 0)
+	if err != nil {
+		t.Fatalf("Failed to parse file: %v", err)
+	}
+
+	var ifStmt ast.Node
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		if s, ok := n.(*ast.IfStmt); ok {
+			ifStmt = s
+
+			return false
+		}
+
+		return true
+	})
+
+	if ifStmt == nil {
+		t.Fatal("IfStmt not found")
+	}
+
+	mutants := mutator.Mutate(ifStmt, fset)
+
+	if len(mutants) != 2 {
+		t.Fatalf("Expected 2 mutants, got %d", len(mutants))
+	}
+
+	mutatedValues := make(map[string]bool)
+
+	for _, m := range mutants {
+		if m.Type != branchConditionType {
+			t.Errorf("Type = %q, want %q", m.Type, branchConditionType)
+		}
+
+		if m.Original == "" {
+			t.Error("Expected non-empty Original")
+		}
+
+		if m.Mutated == "" {
+			t.Error("Expected non-empty Mutated")
+		}
+
+		if m.Description == "" {
+			t.Error("Expected non-empty Description")
+		}
+
+		if m.Line <= 0 {
+			t.Errorf("Expected positive line number, got %d", m.Line)
+		}
+
+		mutatedValues[m.Mutated] = true
+	}
+
+	if !mutatedValues[boolTrue] {
+		t.Error("Expected a mutant with Mutated=true")
+	}
+
+	if !mutatedValues[boolFalse] {
+		t.Error("Expected a mutant with Mutated=false")
+	}
+}
+
+func TestBranchMutator_Apply(t *testing.T) {
+	t.Parallel()
+
+	mutator := &BranchMutator{}
+	fset := token.NewFileSet()
+
+	file, err := parser.ParseFile(fset, "test.go", branchIfSimpleSrc, 0)
+	if err != nil {
+		t.Fatalf("Failed to parse file: %v", err)
+	}
+
+	var ifStmt *ast.IfStmt
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		if s, ok := n.(*ast.IfStmt); ok {
+			ifStmt = s
+
+			return false
+		}
+
+		return true
+	})
+
+	if ifStmt == nil {
+		t.Fatal("IfStmt not found")
+	}
+
+	mutant := Mutant{
+		Type:    branchConditionType,
+		Mutated: boolTrue,
+	}
+
+	if !mutator.Apply(ifStmt, mutant) {
+		t.Error("Apply() = false, want true")
+	}
+
+	ident, ok := ifStmt.Cond.(*ast.Ident)
+	if !ok {
+		t.Fatal("Expected *ast.Ident as Cond after Apply")
+	}
+
+	if ident.Name != boolTrue {
+		t.Errorf("ident.Name = %q, want %q", ident.Name, boolTrue)
+	}
+}
+
+func TestBranchMutator_Apply_NonIfStmt(t *testing.T) {
+	t.Parallel()
+
+	mutator := &BranchMutator{}
+
+	expr, err := parser.ParseExpr("a && b")
+	if err != nil {
+		t.Fatalf("Failed to parse expression: %v", err)
+	}
+
+	mutant := Mutant{
+		Type:    branchConditionType,
+		Mutated: boolTrue,
+	}
+
+	if mutator.Apply(expr, mutant) {
+		t.Error("Apply() = true, want false for non-IfStmt node")
+	}
+}
+
+func TestBranchMutator_Apply_WrongType(t *testing.T) {
+	t.Parallel()
+
+	mutator := &BranchMutator{}
+	fset := token.NewFileSet()
+
+	file, err := parser.ParseFile(fset, "test.go", branchIfSimpleSrc, 0)
+	if err != nil {
+		t.Fatalf("Failed to parse file: %v", err)
+	}
+
+	var ifStmt *ast.IfStmt
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		if s, ok := n.(*ast.IfStmt); ok {
+			ifStmt = s
+
+			return false
+		}
+
+		return true
+	})
+
+	if ifStmt == nil {
+		t.Fatal("IfStmt not found")
+	}
+
+	mutant := Mutant{
+		Type:    "unknown_type",
+		Mutated: boolTrue,
+	}
+
+	if mutator.Apply(ifStmt, mutant) {
+		t.Error("Apply() = true, want false for unknown mutation type")
+	}
+}

--- a/internal/mutation/engine_test.go
+++ b/internal/mutation/engine_test.go
@@ -74,8 +74,8 @@ func TestNew(t *testing.T) {
 		t.Fatal("Expected engine to be non-nil")
 	}
 
-	if len(engine.mutators) != 5 {
-		t.Errorf("Expected 5 mutators, got %d", len(engine.mutators))
+	if len(engine.mutators) != 6 {
+		t.Errorf("Expected 6 mutators, got %d", len(engine.mutators))
 	}
 
 	// Check mutator types
@@ -85,7 +85,7 @@ func TestNew(t *testing.T) {
 		mutatorNames[mutator.Name()] = true
 	}
 
-	expectedMutators := []string{"arithmetic", "conditional", "logical", "return"}
+	expectedMutators := []string{"arithmetic", "branch", "conditional", "logical", "return"}
 
 	for _, expected := range expectedMutators {
 		if !mutatorNames[expected] {
@@ -101,8 +101,8 @@ func TestNew_CustomMutators(t *testing.T) {
 		t.Fatalf("Failed to create mutation engine: %v", err)
 	}
 
-	if len(engine.mutators) != 5 {
-		t.Errorf("Expected 5 mutators (all types enabled by default), got %d", len(engine.mutators))
+	if len(engine.mutators) != 6 {
+		t.Errorf("Expected 6 mutators (all types enabled by default), got %d", len(engine.mutators))
 	}
 }
 
@@ -114,8 +114,8 @@ func TestNew_InvalidMutator(t *testing.T) {
 	}
 
 	// Should ignore invalid mutator
-	if len(engine.mutators) != 5 {
-		t.Errorf("Expected 5 mutators (all types enabled by default), got %d", len(engine.mutators))
+	if len(engine.mutators) != 6 {
+		t.Errorf("Expected 6 mutators (all types enabled by default), got %d", len(engine.mutators))
 	}
 }
 
@@ -733,6 +733,8 @@ func getExpectedMutatorName(mutantType string) string {
 	switch {
 	case strings.HasPrefix(mutantType, "arithmetic_"):
 		return "arithmetic"
+	case strings.HasPrefix(mutantType, "branch_"):
+		return "branch"
 	case strings.HasPrefix(mutantType, "conditional_"):
 		return "conditional"
 	case strings.HasPrefix(mutantType, "logical_"):

--- a/internal/mutation/registry.go
+++ b/internal/mutation/registry.go
@@ -7,6 +7,7 @@ func getAllMutators() []Mutator {
 	return []Mutator{
 		&ArithmeticMutator{},
 		&BitwiseMutator{},
+		&BranchMutator{},
 		&ConditionalMutator{},
 		&LogicalMutator{},
 		&ReturnMutator{},

--- a/internal/mutation/typecheck.go
+++ b/internal/mutation/typecheck.go
@@ -46,7 +46,8 @@ func (tc *TypeChecker) IsValidMutation(node ast.Node, mutant Mutant) bool {
 		logicalBinaryType,
 		logicalNotRemovalType,
 		returnBoolLiteralType,
-		returnZeroValueType:
+		returnZeroValueType,
+		branchConditionType:
 		return true
 
 	default:


### PR DESCRIPTION
## Summary
- Add `BranchMutator` that replaces if-statement conditions with `true` / `false` literals
- Skip conditions that are already boolean literals to avoid redundant mutations
- Add `exprToString` helper function to get text representation of condition expressions
- Register `branchConditionType` in TypeChecker (no type validation needed)

Closes #7

## Test plan
- [x] `TestBranchMutator_CanMutate` - true for if-stmts, false for bool literal conditions and non-if nodes
- [x] `TestBranchMutator_Mutate` - generates 2 mutants (true/false) per if-statement
- [x] `TestBranchMutator_Apply` - condition expression correctly replaced
- [x] `go test -race -shuffle=on ./...` all pass