### PR TITLE
test: add integration tests for remaining mutator types

### DIFF
--- a/.gomuignore
+++ b/.gomuignore
@@ -1,4 +1,5 @@
 cmd/
 internal/mutation/typecheck.go
 internal/mutation/errorhandling.go
+internal/execution/testdata/
 

--- a/internal/execution/overlay_test.go
+++ b/internal/execution/overlay_test.go
@@ -32,6 +32,36 @@ var returnSrc string
 //go:embed testdata/return_false.go
 var returnFalseSrc string
 
+//go:embed testdata/arithmetic.go
+var arithmeticSrc string
+
+//go:embed testdata/arithmetic_sub.go
+var arithmeticSubSrc string
+
+//go:embed testdata/bitwise.go
+var bitwiseSrc string
+
+//go:embed testdata/bitwise_or.go
+var bitwiseOrSrc string
+
+//go:embed testdata/conditional.go
+var conditionalSrc string
+
+//go:embed testdata/conditional_neq.go
+var conditionalNeqSrc string
+
+//go:embed testdata/logical.go
+var logicalSrc string
+
+//go:embed testdata/logical_or.go
+var logicalOrSrc string
+
+//go:embed testdata/logical_not.go
+var logicalNotSrc string
+
+//go:embed testdata/logical_not_removed.go
+var logicalNotRemovedSrc string
+
 func TestNewOverlayMutator(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -658,6 +688,46 @@ func TestMutateAndApplyIntegration(t *testing.T) {
 			original:   "true",
 			mutated:    "false",
 			want:       returnFalseSrc,
+		},
+		{
+			name:       "arithmetic add replaced with sub",
+			src:        arithmeticSrc,
+			mutantType: "arithmetic_binary",
+			original:   "+",
+			mutated:    "-",
+			want:       arithmeticSubSrc,
+		},
+		{
+			name:       "bitwise and replaced with or",
+			src:        bitwiseSrc,
+			mutantType: "bitwise_binary",
+			original:   "&",
+			mutated:    "|",
+			want:       bitwiseOrSrc,
+		},
+		{
+			name:       "conditional eq replaced with neq",
+			src:        conditionalSrc,
+			mutantType: "conditional_binary",
+			original:   "==",
+			mutated:    "!=",
+			want:       conditionalNeqSrc,
+		},
+		{
+			name:       "logical and replaced with or",
+			src:        logicalSrc,
+			mutantType: "logical_binary",
+			original:   "&&",
+			mutated:    "||",
+			want:       logicalOrSrc,
+		},
+		{
+			name:       "logical not removed",
+			src:        logicalNotSrc,
+			mutantType: "logical_not_removal",
+			original:   "!",
+			mutated:    "",
+			want:       logicalNotRemovedSrc,
 		},
 	}
 

--- a/internal/execution/testdata/arithmetic.go
+++ b/internal/execution/testdata/arithmetic.go
@@ -1,0 +1,5 @@
+package main
+
+func Add(a, b int) int {
+	return a + b
+}

--- a/internal/execution/testdata/arithmetic_sub.go
+++ b/internal/execution/testdata/arithmetic_sub.go
@@ -1,0 +1,5 @@
+package main
+
+func Add(a, b int) int {
+	return a - b
+}

--- a/internal/execution/testdata/bitwise.go
+++ b/internal/execution/testdata/bitwise.go
@@ -1,0 +1,5 @@
+package main
+
+func And(a, b int) int {
+	return a & b
+}

--- a/internal/execution/testdata/bitwise_or.go
+++ b/internal/execution/testdata/bitwise_or.go
@@ -1,0 +1,5 @@
+package main
+
+func And(a, b int) int {
+	return a | b
+}

--- a/internal/execution/testdata/conditional.go
+++ b/internal/execution/testdata/conditional.go
@@ -1,0 +1,5 @@
+package main
+
+func Equal(a, b int) bool {
+	return a == b
+}

--- a/internal/execution/testdata/conditional_neq.go
+++ b/internal/execution/testdata/conditional_neq.go
@@ -1,0 +1,5 @@
+package main
+
+func Equal(a, b int) bool {
+	return a != b
+}

--- a/internal/execution/testdata/logical.go
+++ b/internal/execution/testdata/logical.go
@@ -1,0 +1,5 @@
+package main
+
+func Both(a, b bool) bool {
+	return a && b
+}

--- a/internal/execution/testdata/logical_not.go
+++ b/internal/execution/testdata/logical_not.go
@@ -1,0 +1,5 @@
+package main
+
+func NotZero(ok bool) bool {
+	return !ok
+}

--- a/internal/execution/testdata/logical_not_removed.go
+++ b/internal/execution/testdata/logical_not_removed.go
@@ -1,0 +1,5 @@
+package main
+
+func NotZero(ok bool) bool {
+	return ok
+}

--- a/internal/execution/testdata/logical_or.go
+++ b/internal/execution/testdata/logical_or.go
@@ -1,0 +1,5 @@
+package main
+
+func Both(a, b bool) bool {
+	return a || b
+}


### PR DESCRIPTION
## Summary

- Extend `TestMutateAndApplyIntegration` to cover all mutator types
- Adds cases for ArithmeticMutator, BitwiseMutator, ConditionalMutator, and LogicalMutator (both binary operator replacement and NOT removal via CursorApplier)
- Follow-up to #70 which added the integration test framework and covered Branch/ErrorHandling/Return mutators

Each case generates a mutant from a testdata input file, applies it via `PrepareMutation`, and verifies the mutated file matches the expected output file exactly using `cmp.Diff`. This guards the full `Mutate -> PrepareMutation` pipeline against position-matching regressions for every mutator.

| Mutator | Case | testdata |
|---------|------|----------|
| Arithmetic | `+` -> `-` | arithmetic.go / arithmetic_sub.go |
| Bitwise | `&` -> `\|` | bitwise.go / bitwise_or.go |
| Conditional | `==` -> `!=` | conditional.go / conditional_neq.go |
| Logical (binary) | `&&` -> `\|\|` | logical.go / logical_or.go |
| Logical (NOT removal) | `!ok` -> `ok` | logical_not.go / logical_not_removed.go |

## Note

Added `internal/execution/testdata/` to `.gomuignore`. The new testdata fixtures have no tests, so the self-hosted mutation-test CI was picking them up via incremental analysis (git diff) and reporting a 0% score. This exposes a separate bug: the incremental analyzer's file discovery (`internal/analysis/git.go`) does not skip `testdata`/`vendor` directories, unlike the non-incremental analyzer (`internal/analysis/analyzer.go`). Worth a follow-up issue to align both code paths.

## Test plan

- [x] All existing tests pass (`go test ./... -shuffle=on -race`)
- [x] 8/8 integration test cases pass
- [x] mutation-test CI passes (testdata excluded)