### PR TITLE
fix: skip testdata and vendor in incremental file discovery

### DIFF
--- a/.gomuignore
+++ b/.gomuignore
@@ -1,5 +1,4 @@
 cmd/
 internal/mutation/typecheck.go
 internal/mutation/errorhandling.go
-internal/execution/testdata/
 

--- a/internal/analysis/analyzer.go
+++ b/internal/analysis/analyzer.go
@@ -71,15 +71,8 @@ func (a *Analyzer) shouldSkipDirectory(rootPath, path string) bool {
 		}
 	}
 
-	// Skip standard excluded directories
-	excludeDirs := []string{"vendor", "testdata"}
-	for _, exclude := range excludeDirs {
-		if strings.Contains(path, exclude) {
-			return true
-		}
-	}
-
-	return false
+	// Skip standard excluded directories (vendor, testdata)
+	return IsExcludedPath(path)
 }
 
 // shouldIgnoreFile checks if a file should be ignored.

--- a/internal/analysis/git.go
+++ b/internal/analysis/git.go
@@ -72,6 +72,11 @@ func (g *GitIntegration) GetChangedFiles(baseBranch string) ([]string, error) {
 
 	for _, file := range files {
 		if IsGoSourceFile(file) {
+			// Skip standard excluded directories (vendor, testdata)
+			if IsExcludedPath(file) {
+				continue
+			}
+
 			// Check if file should be ignored by .gomuignore
 			if g.ignoreParser != nil && g.ignoreParser.ShouldIgnore(file) {
 				continue
@@ -113,10 +118,9 @@ func (g *GitIntegration) GetAllGoFiles() ([]string, error) {
 			return err
 		}
 
-		// Skip hidden directories and vendor
+		// Skip hidden directories and standard excluded directories (vendor, testdata)
 		if info.IsDir() {
-			name := info.Name()
-			if strings.HasPrefix(name, ".") || name == "vendor" {
+			if strings.HasPrefix(info.Name(), ".") || IsExcludedPath(GetRelativePath(g.workDir, path)) {
 				return filepath.SkipDir
 			}
 

--- a/internal/analysis/git_test.go
+++ b/internal/analysis/git_test.go
@@ -37,10 +37,12 @@ func TestGitIntegration_GetAllGoFiles(t *testing.T) {
 		"main_test.go",  // Should be excluded
 		"utils_test.go", // Should be excluded
 		"subdir/module.go",
-		"subdir/module_test.go", // Should be excluded
-		"vendor/external.go",    // Should be excluded
-		".hidden/file.go",       // Should be excluded
-		"README.md",             // Should be excluded
+		"subdir/module_test.go",     // Should be excluded
+		"vendor/external.go",        // Should be excluded
+		"testdata/fixture.go",       // Should be excluded
+		"subdir/testdata/nested.go", // Should be excluded (nested testdata)
+		".hidden/file.go",           // Should be excluded
+		"README.md",                 // Should be excluded
 	}
 
 	for _, file := range files {

--- a/internal/analysis/path_utils.go
+++ b/internal/analysis/path_utils.go
@@ -25,3 +25,24 @@ func IsGoSourceFile(path string) bool {
 func IsGoTestFile(path string) bool {
 	return strings.HasSuffix(path, "_test.go")
 }
+
+// excludedDirs are directories excluded from mutation testing regardless of
+// which file-discovery path (incremental git diff or full walk) is used.
+var excludedDirs = []string{"vendor", "testdata"}
+
+// IsExcludedPath reports whether the given path lies within an excluded
+// directory (vendor or testdata). The path may use either OS-specific or
+// forward slashes; it is matched per path segment so substrings such as
+// "myvendor" are not falsely excluded.
+func IsExcludedPath(path string) bool {
+	segments := strings.Split(filepath.ToSlash(path), "/")
+	for _, seg := range segments {
+		for _, excluded := range excludedDirs {
+			if seg == excluded {
+				return true
+			}
+		}
+	}
+
+	return false
+}

--- a/internal/analysis/path_utils_test.go
+++ b/internal/analysis/path_utils_test.go
@@ -1,0 +1,64 @@
+package analysis
+
+import "testing"
+
+func TestIsExcludedPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{
+			name: "vendor directory",
+			path: "vendor/external.go",
+			want: true,
+		},
+		{
+			name: "testdata directory",
+			path: "testdata/fixture.go",
+			want: true,
+		},
+		{
+			name: "nested testdata directory",
+			path: "internal/execution/testdata/arithmetic.go",
+			want: true,
+		},
+		{
+			name: "nested vendor directory",
+			path: "internal/vendor/pkg/lib.go",
+			want: true,
+		},
+		{
+			name: "vendor as exact directory segment",
+			path: "vendor",
+			want: true,
+		},
+		{
+			name: "regular source file",
+			path: "internal/mutation/engine.go",
+			want: false,
+		},
+		{
+			name: "substring vendor is not excluded",
+			path: "internal/myvendor/lib.go",
+			want: false,
+		},
+		{
+			name: "substring testdata is not excluded",
+			path: "internal/testdatautil/helper.go",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := IsExcludedPath(tt.path); got != tt.want {
+				t.Errorf("IsExcludedPath(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- The incremental analyzer's git-based file discovery (`GetChangedFiles`, `GetAllGoFiles` in `internal/analysis/git.go`) did not skip `testdata`/`vendor` directories, while the non-incremental analyzer (`internal/analysis/analyzer.go`) did
- This caused testdata Go files to be mutation-tested under incremental analysis, producing misleading scores (testdata fixtures with no tests reported as 0%)
- Extract the skip rule into a shared `IsExcludedPath` helper and apply it in both code paths
- Remove the now-redundant `internal/execution/testdata/` entry from `.gomuignore` (added as a workaround in #75)

Closes #76

## Details

`IsExcludedPath` matches per path segment, so substrings like `myvendor` or `testdatautil` are **not** falsely excluded - unlike the previous `strings.Contains` approach in `analyzer.go`, which this PR also replaces.

## Test plan

- [x] `TestIsExcludedPath` covers vendor/testdata, nested dirs, exact segments, and substring false-positives
- [x] `TestGitIntegration_GetAllGoFiles` extended with testdata and nested-testdata exclusion cases
- [x] All tests pass (`go test ./... -shuffle=on -race`)
- [x] Verified locally: `gomu run . --incremental=false` no longer processes any `testdata/` files even with the `.gomuignore` entry removed