### PR TITLE
feat: add invert negatives mutation operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,9 @@ testdata/
 - Replace `>>` with `<<`
 - Replace `<<` with `>>`
 
+### Invert Negatives Mutations
+- Replace unary `-x` with unary `+x`
+
 ## CI/CD Integration
 
 ### GitHub Actions

--- a/internal/execution/overlay_test.go
+++ b/internal/execution/overlay_test.go
@@ -62,6 +62,12 @@ var logicalNotSrc string
 //go:embed testdata/logical_not_removed.go
 var logicalNotRemovedSrc string
 
+//go:embed testdata/invertnegatives.go
+var invertNegativesSrc string
+
+//go:embed testdata/invertnegatives_plus.go
+var invertNegativesPlusSrc string
+
 func TestNewOverlayMutator(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -728,6 +734,14 @@ func TestMutateAndApplyIntegration(t *testing.T) {
 			original:   "!",
 			mutated:    "",
 			want:       logicalNotRemovedSrc,
+		},
+		{
+			name:       "unary minus inverted to plus",
+			src:        invertNegativesSrc,
+			mutantType: "invert_negatives",
+			original:   "-",
+			mutated:    "+",
+			want:       invertNegativesPlusSrc,
 		},
 	}
 

--- a/internal/execution/testdata/invertnegatives.go
+++ b/internal/execution/testdata/invertnegatives.go
@@ -1,0 +1,5 @@
+package main
+
+func Negate(a int) int {
+	return -a
+}

--- a/internal/execution/testdata/invertnegatives_plus.go
+++ b/internal/execution/testdata/invertnegatives_plus.go
@@ -1,0 +1,5 @@
+package main
+
+func Negate(a int) int {
+	return +a
+}

--- a/internal/mutation/engine_test.go
+++ b/internal/mutation/engine_test.go
@@ -74,8 +74,8 @@ func TestNew(t *testing.T) {
 		t.Fatal("Expected engine to be non-nil")
 	}
 
-	if len(engine.mutators) != 7 {
-		t.Errorf("Expected 7 mutators, got %d", len(engine.mutators))
+	if len(engine.mutators) != 8 {
+		t.Errorf("Expected 8 mutators, got %d", len(engine.mutators))
 	}
 
 	// Check mutator types
@@ -85,7 +85,7 @@ func TestNew(t *testing.T) {
 		mutatorNames[mutator.Name()] = true
 	}
 
-	expectedMutators := []string{"arithmetic", "branch", "conditional", "error_handling", "logical", "return"}
+	expectedMutators := []string{"arithmetic", "branch", "conditional", "error_handling", "invert_negatives", "logical", "return"}
 
 	for _, expected := range expectedMutators {
 		if !mutatorNames[expected] {
@@ -101,8 +101,8 @@ func TestNew_CustomMutators(t *testing.T) {
 		t.Fatalf("Failed to create mutation engine: %v", err)
 	}
 
-	if len(engine.mutators) != 7 {
-		t.Errorf("Expected 7 mutators (all types enabled by default), got %d", len(engine.mutators))
+	if len(engine.mutators) != 8 {
+		t.Errorf("Expected 8 mutators (all types enabled by default), got %d", len(engine.mutators))
 	}
 }
 
@@ -114,8 +114,8 @@ func TestNew_InvalidMutator(t *testing.T) {
 	}
 
 	// Should ignore invalid mutator
-	if len(engine.mutators) != 7 {
-		t.Errorf("Expected 7 mutators (all types enabled by default), got %d", len(engine.mutators))
+	if len(engine.mutators) != 8 {
+		t.Errorf("Expected 8 mutators (all types enabled by default), got %d", len(engine.mutators))
 	}
 }
 

--- a/internal/mutation/invertnegatives.go
+++ b/internal/mutation/invertnegatives.go
@@ -1,0 +1,76 @@
+package mutation
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+)
+
+const (
+	invertNegativesMutatorName = "invert_negatives"
+	invertNegativesType        = "invert_negatives"
+)
+
+// InvertNegativesMutator mutates unary minus operators to unary plus.
+type InvertNegativesMutator struct {
+}
+
+// Name returns the name of the mutator.
+func (m *InvertNegativesMutator) Name() string {
+	return invertNegativesMutatorName
+}
+
+// CanMutate returns true if the node can be mutated by this mutator.
+func (m *InvertNegativesMutator) CanMutate(node ast.Node) bool {
+	if n, ok := node.(*ast.UnaryExpr); ok {
+		return n.Op == token.SUB
+	}
+
+	return false
+}
+
+// Mutate generates mutants for the given node.
+func (m *InvertNegativesMutator) Mutate(node ast.Node, fset *token.FileSet) []Mutant {
+	expr, ok := node.(*ast.UnaryExpr)
+	if !ok || expr.Op != token.SUB {
+		return nil
+	}
+
+	pos := fset.Position(node.Pos())
+
+	return []Mutant{
+		{
+			Line:        pos.Line,
+			Column:      pos.Column,
+			Type:        invertNegativesType,
+			Original:    token.SUB.String(),
+			Mutated:     token.ADD.String(),
+			Description: fmt.Sprintf("Replace unary %s with unary %s", token.SUB.String(), token.ADD.String()),
+		},
+	}
+}
+
+// Apply applies the mutation to the given AST node.
+func (m *InvertNegativesMutator) Apply(node ast.Node, mutant Mutant) bool {
+	if mutant.Type != invertNegativesType {
+		return false
+	}
+
+	expr, ok := node.(*ast.UnaryExpr)
+	if !ok || expr.Op != token.SUB {
+		return false
+	}
+
+	if expr.Op.String() != mutant.Original {
+		return false
+	}
+
+	newOp := stringToToken(mutant.Mutated)
+	if newOp == token.ILLEGAL {
+		return false
+	}
+
+	expr.Op = newOp
+
+	return true
+}

--- a/internal/mutation/invertnegatives_test.go
+++ b/internal/mutation/invertnegatives_test.go
@@ -1,0 +1,239 @@
+package mutation
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+func TestInvertNegativesMutator_Name(t *testing.T) {
+	t.Parallel()
+
+	mutator := &InvertNegativesMutator{}
+	if mutator.Name() != invertNegativesMutatorName {
+		t.Errorf("Expected name %q, got %s", invertNegativesMutatorName, mutator.Name())
+	}
+}
+
+func TestInvertNegativesMutator_CanMutate(t *testing.T) {
+	t.Parallel()
+
+	mutator := &InvertNegativesMutator{}
+
+	tests := []struct {
+		name     string
+		code     string
+		expected bool
+	}{
+		{
+			name:     "unary minus on identifier",
+			code:     "-a",
+			expected: true,
+		},
+		{
+			name:     "unary minus on literal",
+			code:     "-5",
+			expected: true,
+		},
+		{
+			name:     "unary plus",
+			code:     "+a",
+			expected: false,
+		},
+		{
+			name:     "logical not",
+			code:     "!a",
+			expected: false,
+		},
+		{
+			name:     "binary subtraction",
+			code:     "a - b",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			expr, err := parser.ParseExpr(tt.code)
+			if err != nil {
+				t.Fatalf("Failed to parse expression: %v", err)
+			}
+
+			if canMutate := mutator.CanMutate(expr); canMutate != tt.expected {
+				t.Errorf("CanMutate() = %v, expected %v", canMutate, tt.expected)
+			}
+		})
+	}
+}
+
+func TestInvertNegativesMutator_Mutate(t *testing.T) {
+	t.Parallel()
+
+	mutator := &InvertNegativesMutator{}
+	fset := token.NewFileSet()
+
+	src := "package main\nfunc test() { _ = -a }"
+
+	file, err := parser.ParseFile(fset, "test.go", src, 0)
+	if err != nil {
+		t.Fatalf("Failed to parse file: %v", err)
+	}
+
+	var expr ast.Node
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		if ue, ok := n.(*ast.UnaryExpr); ok {
+			expr = ue
+
+			return false
+		}
+
+		return true
+	})
+
+	if expr == nil {
+		t.Fatal("UnaryExpr not found")
+	}
+
+	mutants := mutator.Mutate(expr, fset)
+
+	if len(mutants) != 1 {
+		t.Fatalf("Expected 1 mutant, got %d", len(mutants))
+	}
+
+	m := mutants[0]
+
+	if m.Type != invertNegativesType {
+		t.Errorf("Type = %q, want %q", m.Type, invertNegativesType)
+	}
+
+	if m.Original != "-" {
+		t.Errorf("Original = %q, want %q", m.Original, "-")
+	}
+
+	if m.Mutated != "+" {
+		t.Errorf("Mutated = %q, want %q", m.Mutated, "+")
+	}
+
+	if m.Line <= 0 {
+		t.Errorf("Expected positive line number, got %d", m.Line)
+	}
+
+	if m.Description == "" {
+		t.Error("Expected non-empty description")
+	}
+}
+
+func TestInvertNegativesMutator_Mutate_NonUnaryMinus(t *testing.T) {
+	t.Parallel()
+
+	mutator := &InvertNegativesMutator{}
+	fset := token.NewFileSet()
+
+	expr, err := parser.ParseExpr("!a")
+	if err != nil {
+		t.Fatalf("Failed to parse expression: %v", err)
+	}
+
+	if mutants := mutator.Mutate(expr, fset); mutants != nil {
+		t.Errorf("Mutate() = %v, want nil for non unary-minus node", mutants)
+	}
+}
+
+func TestInvertNegativesMutator_Apply(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		code       string
+		mutantType string
+		original   string
+		mutated    string
+		expected   bool
+		wantOp     token.Token
+	}{
+		{
+			name:       "apply unary minus to plus",
+			code:       "-a",
+			mutantType: invertNegativesType,
+			original:   "-",
+			mutated:    "+",
+			expected:   true,
+			wantOp:     token.ADD,
+		},
+		{
+			name:       "wrong mutant type",
+			code:       "-a",
+			mutantType: "unknown",
+			original:   "-",
+			mutated:    "+",
+			expected:   false,
+			wantOp:     token.SUB,
+		},
+		{
+			name:       "wrong original operator",
+			code:       "-a",
+			mutantType: invertNegativesType,
+			original:   "+",
+			mutated:    "+",
+			expected:   false,
+			wantOp:     token.SUB,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mutator := &InvertNegativesMutator{}
+
+			expr, err := parser.ParseExpr(tt.code)
+			if err != nil {
+				t.Fatalf("Failed to parse expression: %v", err)
+			}
+
+			mutant := Mutant{
+				Type:     tt.mutantType,
+				Original: tt.original,
+				Mutated:  tt.mutated,
+			}
+
+			if result := mutator.Apply(expr, mutant); result != tt.expected {
+				t.Errorf("Apply() = %v, expected %v", result, tt.expected)
+			}
+
+			ue, ok := expr.(*ast.UnaryExpr)
+			if !ok {
+				t.Fatalf("expected *ast.UnaryExpr, got %T", expr)
+			}
+
+			if ue.Op != tt.wantOp {
+				t.Errorf("Op = %v, want %v", ue.Op, tt.wantOp)
+			}
+		})
+	}
+}
+
+func TestInvertNegativesMutator_Apply_NonUnaryNode(t *testing.T) {
+	t.Parallel()
+
+	mutator := &InvertNegativesMutator{}
+
+	expr, err := parser.ParseExpr("a - b")
+	if err != nil {
+		t.Fatalf("Failed to parse expression: %v", err)
+	}
+
+	mutant := Mutant{
+		Type:     invertNegativesType,
+		Original: "-",
+		Mutated:  "+",
+	}
+
+	if mutator.Apply(expr, mutant) {
+		t.Error("Apply() = true, want false for non-UnaryExpr node")
+	}
+}

--- a/internal/mutation/registry.go
+++ b/internal/mutation/registry.go
@@ -10,6 +10,7 @@ func getAllMutators() []Mutator {
 		&BranchMutator{},
 		&ConditionalMutator{},
 		&ErrorHandlingMutator{},
+		&InvertNegativesMutator{},
 		&LogicalMutator{},
 		&ReturnMutator{},
 	}


### PR DESCRIPTION
## Summary
- Add `InvertNegativesMutator` that mutates unary minus (`-x`) to unary plus (`+x`)
- Tests whether negation of values is properly covered by tests (gremlins INVERT_NEGATIVES equivalent)
- Auto-registered via `go generate`; integrated into the overlay apply pipeline

## Changes
- `internal/mutation/invertnegatives.go` — new mutator (`CanMutate` / `Mutate` / `Apply`)
- `internal/mutation/invertnegatives_test.go` — unit tests (Name/CanMutate/Mutate/Apply)
- `internal/mutation/registry.go` — regenerated (8 mutators)
- `internal/mutation/engine_test.go` — updated expected mutator count and name list
- `internal/execution/overlay_test.go` + testdata — end-to-end golden test for the new operator
- `README.md` — documented the new mutation type

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (all packages pass)
- [x] `TestMutateAndApplyIntegration` covers `-a` -> `+a`
- [x] `golangci-lint run` clean on new files

Closes #68
