### PR TITLE
feat: add remove self-assignments mutation operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,9 @@ testdata/
 ### Invert Negatives Mutations
 - Replace unary `-x` with unary `+x`
 
+### Remove Self-Assignments Mutations
+- Replace compound assignments (`+=`, `-=`, `*=`, `/=`, `%=`, `&=`, `|=`, `^=`, `<<=`, `>>=`, `&^=`) with simple assignment (`=`)
+
 ## CI/CD Integration
 
 ### GitHub Actions

--- a/internal/execution/overlay_test.go
+++ b/internal/execution/overlay_test.go
@@ -68,6 +68,12 @@ var invertNegativesSrc string
 //go:embed testdata/invertnegatives_plus.go
 var invertNegativesPlusSrc string
 
+//go:embed testdata/selfassign.go
+var selfAssignSrc string
+
+//go:embed testdata/selfassign_simple.go
+var selfAssignSimpleSrc string
+
 func TestNewOverlayMutator(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -742,6 +748,14 @@ func TestMutateAndApplyIntegration(t *testing.T) {
 			original:   "-",
 			mutated:    "+",
 			want:       invertNegativesPlusSrc,
+		},
+		{
+			name:       "compound assignment replaced with simple assignment",
+			src:        selfAssignSrc,
+			mutantType: "remove_self_assignments",
+			original:   "+=",
+			mutated:    "=",
+			want:       selfAssignSimpleSrc,
 		},
 	}
 

--- a/internal/execution/testdata/selfassign.go
+++ b/internal/execution/testdata/selfassign.go
@@ -1,0 +1,7 @@
+package main
+
+func Accumulate(a, b int) int {
+	a += b
+
+	return a
+}

--- a/internal/execution/testdata/selfassign_simple.go
+++ b/internal/execution/testdata/selfassign_simple.go
@@ -1,0 +1,7 @@
+package main
+
+func Accumulate(a, b int) int {
+	a = b
+
+	return a
+}

--- a/internal/mutation/engine_test.go
+++ b/internal/mutation/engine_test.go
@@ -74,8 +74,8 @@ func TestNew(t *testing.T) {
 		t.Fatal("Expected engine to be non-nil")
 	}
 
-	if len(engine.mutators) != 8 {
-		t.Errorf("Expected 8 mutators, got %d", len(engine.mutators))
+	if len(engine.mutators) != 9 {
+		t.Errorf("Expected 9 mutators, got %d", len(engine.mutators))
 	}
 
 	// Check mutator types
@@ -85,7 +85,7 @@ func TestNew(t *testing.T) {
 		mutatorNames[mutator.Name()] = true
 	}
 
-	expectedMutators := []string{"arithmetic", "branch", "conditional", "error_handling", "invert_negatives", "logical", "return"}
+	expectedMutators := []string{"arithmetic", "branch", "conditional", "error_handling", "invert_negatives", "logical", "remove_self_assignments", "return"}
 
 	for _, expected := range expectedMutators {
 		if !mutatorNames[expected] {
@@ -101,8 +101,8 @@ func TestNew_CustomMutators(t *testing.T) {
 		t.Fatalf("Failed to create mutation engine: %v", err)
 	}
 
-	if len(engine.mutators) != 8 {
-		t.Errorf("Expected 8 mutators (all types enabled by default), got %d", len(engine.mutators))
+	if len(engine.mutators) != 9 {
+		t.Errorf("Expected 9 mutators (all types enabled by default), got %d", len(engine.mutators))
 	}
 }
 
@@ -114,8 +114,8 @@ func TestNew_InvalidMutator(t *testing.T) {
 	}
 
 	// Should ignore invalid mutator
-	if len(engine.mutators) != 8 {
-		t.Errorf("Expected 8 mutators (all types enabled by default), got %d", len(engine.mutators))
+	if len(engine.mutators) != 9 {
+		t.Errorf("Expected 9 mutators (all types enabled by default), got %d", len(engine.mutators))
 	}
 }
 

--- a/internal/mutation/registry.go
+++ b/internal/mutation/registry.go
@@ -12,6 +12,7 @@ func getAllMutators() []Mutator {
 		&ErrorHandlingMutator{},
 		&InvertNegativesMutator{},
 		&LogicalMutator{},
+		&RemoveSelfAssignmentsMutator{},
 		&ReturnMutator{},
 	}
 }

--- a/internal/mutation/removeselfassignments.go
+++ b/internal/mutation/removeselfassignments.go
@@ -1,0 +1,88 @@
+package mutation
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+)
+
+const (
+	removeSelfAssignmentsMutatorName = "remove_self_assignments"
+	removeSelfAssignmentsType        = "remove_self_assignments"
+)
+
+// RemoveSelfAssignmentsMutator mutates compound assignment operators
+// (e.g. +=, -=, &^=) to a simple assignment (=).
+type RemoveSelfAssignmentsMutator struct {
+}
+
+// Name returns the name of the mutator.
+func (m *RemoveSelfAssignmentsMutator) Name() string {
+	return removeSelfAssignmentsMutatorName
+}
+
+// CanMutate returns true if the node can be mutated by this mutator.
+func (m *RemoveSelfAssignmentsMutator) CanMutate(node ast.Node) bool {
+	if n, ok := node.(*ast.AssignStmt); ok {
+		return m.isCompoundAssignOp(n.Tok)
+	}
+
+	return false
+}
+
+// Mutate generates mutants for the given node.
+func (m *RemoveSelfAssignmentsMutator) Mutate(node ast.Node, fset *token.FileSet) []Mutant {
+	stmt, ok := node.(*ast.AssignStmt)
+	if !ok || !m.isCompoundAssignOp(stmt.Tok) {
+		return nil
+	}
+
+	pos := fset.Position(node.Pos())
+
+	return []Mutant{
+		{
+			Line:        pos.Line,
+			Column:      pos.Column,
+			Type:        removeSelfAssignmentsType,
+			Original:    stmt.Tok.String(),
+			Mutated:     token.ASSIGN.String(),
+			Description: fmt.Sprintf("Replace %s with %s", stmt.Tok.String(), token.ASSIGN.String()),
+		},
+	}
+}
+
+func (m *RemoveSelfAssignmentsMutator) isCompoundAssignOp(op token.Token) bool {
+	switch op {
+	case token.ADD_ASSIGN, token.SUB_ASSIGN, token.MUL_ASSIGN, token.QUO_ASSIGN, token.REM_ASSIGN,
+		token.AND_ASSIGN, token.OR_ASSIGN, token.XOR_ASSIGN,
+		token.SHL_ASSIGN, token.SHR_ASSIGN, token.AND_NOT_ASSIGN:
+		return true
+	default:
+		return false
+	}
+}
+
+// Apply applies the mutation to the given AST node.
+func (m *RemoveSelfAssignmentsMutator) Apply(node ast.Node, mutant Mutant) bool {
+	if mutant.Type != removeSelfAssignmentsType {
+		return false
+	}
+
+	stmt, ok := node.(*ast.AssignStmt)
+	if !ok || !m.isCompoundAssignOp(stmt.Tok) {
+		return false
+	}
+
+	if stmt.Tok.String() != mutant.Original {
+		return false
+	}
+
+	newOp := stringToToken(mutant.Mutated)
+	if newOp == token.ILLEGAL {
+		return false
+	}
+
+	stmt.Tok = newOp
+
+	return true
+}

--- a/internal/mutation/removeselfassignments_test.go
+++ b/internal/mutation/removeselfassignments_test.go
@@ -1,0 +1,275 @@
+package mutation
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+func TestRemoveSelfAssignmentsMutator_Name(t *testing.T) {
+	t.Parallel()
+
+	mutator := &RemoveSelfAssignmentsMutator{}
+	if mutator.Name() != removeSelfAssignmentsMutatorName {
+		t.Errorf("Expected name %q, got %s", removeSelfAssignmentsMutatorName, mutator.Name())
+	}
+}
+
+func TestRemoveSelfAssignmentsMutator_CanMutate(t *testing.T) {
+	t.Parallel()
+
+	mutator := &RemoveSelfAssignmentsMutator{}
+
+	tests := []struct {
+		name     string
+		code     string
+		expected bool
+	}{
+		{name: "add assign", code: "a += b", expected: true},
+		{name: "sub assign", code: "a -= b", expected: true},
+		{name: "mul assign", code: "a *= b", expected: true},
+		{name: "quo assign", code: "a /= b", expected: true},
+		{name: "rem assign", code: "a %= b", expected: true},
+		{name: "and assign", code: "a &= b", expected: true},
+		{name: "or assign", code: "a |= b", expected: true},
+		{name: "xor assign", code: "a ^= b", expected: true},
+		{name: "shl assign", code: "a <<= b", expected: true},
+		{name: "shr assign", code: "a >>= b", expected: true},
+		{name: "and not assign", code: "a &^= b", expected: true},
+		{name: "simple assign", code: "a = b", expected: false},
+		{name: "define", code: "a := b", expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			stmt := parseAssignStmt(t, tt.code)
+
+			if canMutate := mutator.CanMutate(stmt); canMutate != tt.expected {
+				t.Errorf("CanMutate() = %v, expected %v", canMutate, tt.expected)
+			}
+		})
+	}
+}
+
+func TestRemoveSelfAssignmentsMutator_CanMutate_NonAssign(t *testing.T) {
+	t.Parallel()
+
+	mutator := &RemoveSelfAssignmentsMutator{}
+
+	expr, err := parser.ParseExpr("a + b")
+	if err != nil {
+		t.Fatalf("Failed to parse expression: %v", err)
+	}
+
+	if mutator.CanMutate(expr) {
+		t.Error("CanMutate() = true, want false for non-AssignStmt node")
+	}
+}
+
+func TestRemoveSelfAssignmentsMutator_Mutate(t *testing.T) {
+	t.Parallel()
+
+	mutator := &RemoveSelfAssignmentsMutator{}
+	fset := token.NewFileSet()
+
+	tests := []struct {
+		name string
+		code string
+		op   string
+	}{
+		{name: "add assign", code: "a += b", op: "+="},
+		{name: "and not assign", code: "a &^= b", op: "&^="},
+		{name: "shl assign", code: "a <<= b", op: "<<="},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			stmt := parseAssignStmtWithFset(t, fset, tt.code)
+
+			mutants := mutator.Mutate(stmt, fset)
+
+			if len(mutants) != 1 {
+				t.Fatalf("Expected 1 mutant, got %d", len(mutants))
+			}
+
+			m := mutants[0]
+
+			if m.Type != removeSelfAssignmentsType {
+				t.Errorf("Type = %q, want %q", m.Type, removeSelfAssignmentsType)
+			}
+
+			if m.Original != tt.op {
+				t.Errorf("Original = %q, want %q", m.Original, tt.op)
+			}
+
+			if m.Mutated != "=" {
+				t.Errorf("Mutated = %q, want %q", m.Mutated, "=")
+			}
+
+			if m.Line <= 0 {
+				t.Errorf("Expected positive line number, got %d", m.Line)
+			}
+
+			if m.Description == "" {
+				t.Error("Expected non-empty description")
+			}
+		})
+	}
+}
+
+func TestRemoveSelfAssignmentsMutator_Mutate_NonCompound(t *testing.T) {
+	t.Parallel()
+
+	mutator := &RemoveSelfAssignmentsMutator{}
+	fset := token.NewFileSet()
+
+	stmt := parseAssignStmtWithFset(t, fset, "a = b")
+
+	if mutants := mutator.Mutate(stmt, fset); mutants != nil {
+		t.Errorf("Mutate() = %v, want nil for simple assignment", mutants)
+	}
+}
+
+func TestRemoveSelfAssignmentsMutator_Apply(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		code       string
+		mutantType string
+		original   string
+		mutated    string
+		expected   bool
+		wantTok    token.Token
+	}{
+		{
+			name:       "apply add assign to simple assign",
+			code:       "a += b",
+			mutantType: removeSelfAssignmentsType,
+			original:   "+=",
+			mutated:    "=",
+			expected:   true,
+			wantTok:    token.ASSIGN,
+		},
+		{
+			name:       "apply and not assign to simple assign",
+			code:       "a &^= b",
+			mutantType: removeSelfAssignmentsType,
+			original:   "&^=",
+			mutated:    "=",
+			expected:   true,
+			wantTok:    token.ASSIGN,
+		},
+		{
+			name:       "wrong mutant type",
+			code:       "a += b",
+			mutantType: "unknown",
+			original:   "+=",
+			mutated:    "=",
+			expected:   false,
+			wantTok:    token.ADD_ASSIGN,
+		},
+		{
+			name:       "wrong original operator",
+			code:       "a += b",
+			mutantType: removeSelfAssignmentsType,
+			original:   "-=",
+			mutated:    "=",
+			expected:   false,
+			wantTok:    token.ADD_ASSIGN,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mutator := &RemoveSelfAssignmentsMutator{}
+			fset := token.NewFileSet()
+			stmt := parseAssignStmtWithFset(t, fset, tt.code)
+
+			mutant := Mutant{
+				Type:     tt.mutantType,
+				Original: tt.original,
+				Mutated:  tt.mutated,
+			}
+
+			if result := mutator.Apply(stmt, mutant); result != tt.expected {
+				t.Errorf("Apply() = %v, expected %v", result, tt.expected)
+			}
+
+			as, ok := stmt.(*ast.AssignStmt)
+			if !ok {
+				t.Fatalf("expected *ast.AssignStmt, got %T", stmt)
+			}
+
+			if as.Tok != tt.wantTok {
+				t.Errorf("Tok = %v, want %v", as.Tok, tt.wantTok)
+			}
+		})
+	}
+}
+
+func TestRemoveSelfAssignmentsMutator_Apply_NonAssignNode(t *testing.T) {
+	t.Parallel()
+
+	mutator := &RemoveSelfAssignmentsMutator{}
+
+	expr, err := parser.ParseExpr("a + b")
+	if err != nil {
+		t.Fatalf("Failed to parse expression: %v", err)
+	}
+
+	mutant := Mutant{
+		Type:     removeSelfAssignmentsType,
+		Original: "+=",
+		Mutated:  "=",
+	}
+
+	if mutator.Apply(expr, mutant) {
+		t.Error("Apply() = true, want false for non-AssignStmt node")
+	}
+}
+
+// parseAssignStmt parses a single assignment statement and returns its AST node.
+func parseAssignStmt(t *testing.T, code string) ast.Node {
+	t.Helper()
+
+	return parseAssignStmtWithFset(t, token.NewFileSet(), code)
+}
+
+// parseAssignStmtWithFset parses a single assignment statement using the given file set.
+// Only syntax is checked, so undeclared identifiers in code are fine.
+func parseAssignStmtWithFset(t *testing.T, fset *token.FileSet, code string) ast.Node {
+	t.Helper()
+
+	src := "package main\nfunc test() {\n\t" + code + "\n}"
+
+	file, err := parser.ParseFile(fset, "test.go", src, 0)
+	if err != nil {
+		t.Fatalf("Failed to parse file: %v", err)
+	}
+
+	var stmt ast.Node
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		if as, ok := n.(*ast.AssignStmt); ok {
+			stmt = as
+
+			return false
+		}
+
+		return true
+	})
+
+	if stmt == nil {
+		t.Fatalf("AssignStmt not found in: %s", code)
+	}
+
+	return stmt
+}

--- a/internal/mutation/token.go
+++ b/internal/mutation/token.go
@@ -23,6 +23,10 @@ func stringToToken(s string) token.Token {
 	case "--":
 		return token.DEC
 
+	// Simple assignment
+	case "=":
+		return token.ASSIGN
+
 	// Arithmetic assignment
 	case "+=":
 		return token.ADD_ASSIGN
@@ -32,6 +36,8 @@ func stringToToken(s string) token.Token {
 		return token.MUL_ASSIGN
 	case "/=":
 		return token.QUO_ASSIGN
+	case "%=":
+		return token.REM_ASSIGN
 
 	// Conditional
 	case "==":


### PR DESCRIPTION
## Summary
- Add `RemoveSelfAssignmentsMutator` that mutates compound assignment operators to a simple assignment (`=`)
- Covers `+=`, `-=`, `*=`, `/=`, `%=`, `&=`, `|=`, `^=`, `<<=`, `>>=`, `&^=` (gremlins REMOVE_SELF_ASSIGNMENTS equivalent)
- Auto-registered via `go generate`; integrated into the overlay apply pipeline

## Changes
- `internal/mutation/removeselfassignments.go` — new mutator (`CanMutate` / `Mutate` / `Apply`)
- `internal/mutation/removeselfassignments_test.go` — unit tests for all compound operators
- `internal/mutation/token.go` — add `=`, `%=` mappings to `stringToToken`
- `internal/mutation/registry.go` — regenerated (8 mutators)
- `internal/mutation/engine_test.go` — updated expected mutator count and name list
- `internal/execution/overlay_test.go` + testdata — end-to-end golden test (`a += b` -> `a = b`)
- `README.md` — documented the new mutation type

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (all packages pass)
- [x] `TestMutateAndApplyIntegration` covers `a += b` -> `a = b`
- [x] `golangci-lint run` clean on new files

Closes #69
