### PR TITLE
feat: add break and continue mutation operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,9 @@ testdata/
 ### Remove Self-Assignments Mutations
 - Replace compound assignments (`+=`, `-=`, `*=`, `/=`, `%=`, `&=`, `|=`, `^=`, `<<=`, `>>=`, `&^=`) with simple assignment (`=`)
 
+### Break and Continue Mutations
+- Swap `break` and `continue` statements (label-less only)
+
 ## CI/CD Integration
 
 ### GitHub Actions

--- a/internal/execution/overlay_test.go
+++ b/internal/execution/overlay_test.go
@@ -74,6 +74,12 @@ var selfAssignSrc string
 //go:embed testdata/selfassign_simple.go
 var selfAssignSimpleSrc string
 
+//go:embed testdata/breakcontinue.go
+var breakContinueSrc string
+
+//go:embed testdata/breakcontinue_continue.go
+var breakContinueContinueSrc string
+
 func TestNewOverlayMutator(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -756,6 +762,14 @@ func TestMutateAndApplyIntegration(t *testing.T) {
 			original:   "+=",
 			mutated:    "=",
 			want:       selfAssignSimpleSrc,
+		},
+		{
+			name:       "break replaced with continue",
+			src:        breakContinueSrc,
+			mutantType: "break_continue",
+			original:   "break",
+			mutated:    "continue",
+			want:       breakContinueContinueSrc,
 		},
 	}
 

--- a/internal/execution/testdata/breakcontinue.go
+++ b/internal/execution/testdata/breakcontinue.go
@@ -1,0 +1,10 @@
+package main
+
+func Count(items []int) int {
+	count := 0
+	for range items {
+		count++
+		break
+	}
+	return count
+}

--- a/internal/execution/testdata/breakcontinue_continue.go
+++ b/internal/execution/testdata/breakcontinue_continue.go
@@ -1,0 +1,10 @@
+package main
+
+func Count(items []int) int {
+	count := 0
+	for range items {
+		count++
+		continue
+	}
+	return count
+}

--- a/internal/mutation/breakcontinue.go
+++ b/internal/mutation/breakcontinue.go
@@ -1,0 +1,91 @@
+package mutation
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+)
+
+const (
+	breakContinueMutatorName = "break_continue"
+	breakContinueType        = "break_continue"
+)
+
+// BreakContinueMutator swaps break and continue branch statements.
+type BreakContinueMutator struct {
+}
+
+// Name returns the name of the mutator.
+func (m *BreakContinueMutator) Name() string {
+	return breakContinueMutatorName
+}
+
+// CanMutate returns true if the node can be mutated by this mutator.
+func (m *BreakContinueMutator) CanMutate(node ast.Node) bool {
+	stmt, ok := node.(*ast.BranchStmt)
+	if !ok {
+		return false
+	}
+
+	// Only swap label-less break/continue. Labeled statements reference a
+	// specific loop/switch and swapping them is far more likely to be invalid.
+	if stmt.Label != nil {
+		return false
+	}
+
+	return stmt.Tok == token.BREAK || stmt.Tok == token.CONTINUE
+}
+
+// Mutate generates mutants for the given node.
+func (m *BreakContinueMutator) Mutate(node ast.Node, fset *token.FileSet) []Mutant {
+	if !m.CanMutate(node) {
+		return nil
+	}
+
+	stmt := node.(*ast.BranchStmt) //nolint:forcetypeassert // guarded by CanMutate
+	newOp := m.swap(stmt.Tok)
+	pos := fset.Position(stmt.Pos())
+
+	return []Mutant{
+		{
+			Line:        pos.Line,
+			Column:      pos.Column,
+			Type:        breakContinueType,
+			Original:    stmt.Tok.String(),
+			Mutated:     newOp.String(),
+			Description: fmt.Sprintf("Replace %s with %s", stmt.Tok.String(), newOp.String()),
+		},
+	}
+}
+
+// Apply applies the mutation to the given AST node.
+func (m *BreakContinueMutator) Apply(node ast.Node, mutant Mutant) bool {
+	if mutant.Type != breakContinueType {
+		return false
+	}
+
+	stmt, ok := node.(*ast.BranchStmt)
+	if !ok || stmt.Label != nil {
+		return false
+	}
+
+	if stmt.Tok != token.BREAK && stmt.Tok != token.CONTINUE {
+		return false
+	}
+
+	if stmt.Tok.String() != mutant.Original {
+		return false
+	}
+
+	stmt.Tok = m.swap(stmt.Tok)
+
+	return true
+}
+
+func (m *BreakContinueMutator) swap(op token.Token) token.Token {
+	if op == token.BREAK {
+		return token.CONTINUE
+	}
+
+	return token.BREAK
+}

--- a/internal/mutation/breakcontinue_test.go
+++ b/internal/mutation/breakcontinue_test.go
@@ -1,0 +1,248 @@
+package mutation
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+func parseBranchStmt(t *testing.T, fset *token.FileSet, body string) ast.Node {
+	t.Helper()
+
+	src := "package main\nfunc test() {\n\tfor {\n\t\t" + body + "\n\t}\n}"
+
+	file, err := parser.ParseFile(fset, "test.go", src, 0)
+	if err != nil {
+		t.Fatalf("Failed to parse file: %v", err)
+	}
+
+	var stmt ast.Node
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		if bs, ok := n.(*ast.BranchStmt); ok {
+			stmt = bs
+
+			return false
+		}
+
+		return true
+	})
+
+	if stmt == nil {
+		t.Fatalf("BranchStmt not found in: %s", body)
+	}
+
+	return stmt
+}
+
+func TestBreakContinueMutator_Name(t *testing.T) {
+	t.Parallel()
+
+	mutator := &BreakContinueMutator{}
+	if mutator.Name() != breakContinueMutatorName {
+		t.Errorf("Expected name %q, got %s", breakContinueMutatorName, mutator.Name())
+	}
+}
+
+func TestBreakContinueMutator_CanMutate(t *testing.T) {
+	t.Parallel()
+
+	mutator := &BreakContinueMutator{}
+
+	tests := []struct {
+		name     string
+		body     string
+		expected bool
+	}{
+		{name: "break", body: "break", expected: true},
+		{name: "continue", body: "continue", expected: true},
+		{name: "labeled break", body: "break Loop", expected: false},
+		{name: "labeled continue", body: "continue Loop", expected: false},
+		{name: "goto", body: "goto Loop", expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			fset := token.NewFileSet()
+			stmt := parseBranchStmt(t, fset, tt.body)
+
+			if canMutate := mutator.CanMutate(stmt); canMutate != tt.expected {
+				t.Errorf("CanMutate() = %v, expected %v", canMutate, tt.expected)
+			}
+		})
+	}
+}
+
+func TestBreakContinueMutator_CanMutate_NonBranch(t *testing.T) {
+	t.Parallel()
+
+	mutator := &BreakContinueMutator{}
+
+	expr, err := parser.ParseExpr("a + b")
+	if err != nil {
+		t.Fatalf("Failed to parse expression: %v", err)
+	}
+
+	if mutator.CanMutate(expr) {
+		t.Error("CanMutate() = true, want false for non-BranchStmt node")
+	}
+}
+
+func TestBreakContinueMutator_Mutate(t *testing.T) {
+	t.Parallel()
+
+	mutator := &BreakContinueMutator{}
+
+	tests := []struct {
+		name         string
+		body         string
+		wantOriginal string
+		wantMutated  string
+	}{
+		{name: "break to continue", body: "break", wantOriginal: "break", wantMutated: "continue"},
+		{name: "continue to break", body: "continue", wantOriginal: "continue", wantMutated: "break"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			fset := token.NewFileSet()
+			stmt := parseBranchStmt(t, fset, tt.body)
+
+			mutants := mutator.Mutate(stmt, fset)
+
+			if len(mutants) != 1 {
+				t.Fatalf("Expected 1 mutant, got %d", len(mutants))
+			}
+
+			m := mutants[0]
+
+			if m.Type != breakContinueType {
+				t.Errorf("Type = %q, want %q", m.Type, breakContinueType)
+			}
+
+			if m.Original != tt.wantOriginal {
+				t.Errorf("Original = %q, want %q", m.Original, tt.wantOriginal)
+			}
+
+			if m.Mutated != tt.wantMutated {
+				t.Errorf("Mutated = %q, want %q", m.Mutated, tt.wantMutated)
+			}
+
+			if m.Line <= 0 {
+				t.Errorf("Expected positive line number, got %d", m.Line)
+			}
+
+			if m.Description == "" {
+				t.Error("Expected non-empty description")
+			}
+		})
+	}
+}
+
+func TestBreakContinueMutator_Mutate_Labeled(t *testing.T) {
+	t.Parallel()
+
+	mutator := &BreakContinueMutator{}
+	fset := token.NewFileSet()
+	stmt := parseBranchStmt(t, fset, "break Loop")
+
+	if mutants := mutator.Mutate(stmt, fset); mutants != nil {
+		t.Errorf("Mutate() = %v, want nil for labeled branch statement", mutants)
+	}
+}
+
+func TestBreakContinueMutator_Apply(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		body       string
+		mutantType string
+		original   string
+		expected   bool
+		wantTok    token.Token
+	}{
+		{
+			name:       "apply break to continue",
+			body:       "break",
+			mutantType: breakContinueType,
+			original:   "break",
+			expected:   true,
+			wantTok:    token.CONTINUE,
+		},
+		{
+			name:       "apply continue to break",
+			body:       "continue",
+			mutantType: breakContinueType,
+			original:   "continue",
+			expected:   true,
+			wantTok:    token.BREAK,
+		},
+		{
+			name:       "wrong mutant type",
+			body:       "break",
+			mutantType: "unknown",
+			original:   "break",
+			expected:   false,
+			wantTok:    token.BREAK,
+		},
+		{
+			name:       "wrong original",
+			body:       "break",
+			mutantType: breakContinueType,
+			original:   "continue",
+			expected:   false,
+			wantTok:    token.BREAK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mutator := &BreakContinueMutator{}
+			fset := token.NewFileSet()
+			stmt := parseBranchStmt(t, fset, tt.body)
+
+			mutant := Mutant{
+				Type:     tt.mutantType,
+				Original: tt.original,
+			}
+
+			if result := mutator.Apply(stmt, mutant); result != tt.expected {
+				t.Errorf("Apply() = %v, expected %v", result, tt.expected)
+			}
+
+			bs, ok := stmt.(*ast.BranchStmt)
+			if !ok {
+				t.Fatalf("expected *ast.BranchStmt, got %T", stmt)
+			}
+
+			if bs.Tok != tt.wantTok {
+				t.Errorf("Tok = %v, want %v", bs.Tok, tt.wantTok)
+			}
+		})
+	}
+}
+
+func TestBreakContinueMutator_Apply_NonBranchNode(t *testing.T) {
+	t.Parallel()
+
+	mutator := &BreakContinueMutator{}
+
+	expr, err := parser.ParseExpr("a + b")
+	if err != nil {
+		t.Fatalf("Failed to parse expression: %v", err)
+	}
+
+	mutant := Mutant{Type: breakContinueType, Original: "break"}
+
+	if mutator.Apply(expr, mutant) {
+		t.Error("Apply() = true, want false for non-BranchStmt node")
+	}
+}

--- a/internal/mutation/engine_test.go
+++ b/internal/mutation/engine_test.go
@@ -74,8 +74,8 @@ func TestNew(t *testing.T) {
 		t.Fatal("Expected engine to be non-nil")
 	}
 
-	if len(engine.mutators) != 9 {
-		t.Errorf("Expected 9 mutators, got %d", len(engine.mutators))
+	if len(engine.mutators) != 10 {
+		t.Errorf("Expected 10 mutators, got %d", len(engine.mutators))
 	}
 
 	// Check mutator types
@@ -85,7 +85,7 @@ func TestNew(t *testing.T) {
 		mutatorNames[mutator.Name()] = true
 	}
 
-	expectedMutators := []string{"arithmetic", "branch", "conditional", "error_handling", "invert_negatives", "logical", "remove_self_assignments", "return"}
+	expectedMutators := []string{"arithmetic", "branch", "break_continue", "conditional", "error_handling", "invert_negatives", "logical", "remove_self_assignments", "return"}
 
 	for _, expected := range expectedMutators {
 		if !mutatorNames[expected] {
@@ -101,8 +101,8 @@ func TestNew_CustomMutators(t *testing.T) {
 		t.Fatalf("Failed to create mutation engine: %v", err)
 	}
 
-	if len(engine.mutators) != 9 {
-		t.Errorf("Expected 9 mutators (all types enabled by default), got %d", len(engine.mutators))
+	if len(engine.mutators) != 10 {
+		t.Errorf("Expected 10 mutators (all types enabled by default), got %d", len(engine.mutators))
 	}
 }
 
@@ -114,8 +114,8 @@ func TestNew_InvalidMutator(t *testing.T) {
 	}
 
 	// Should ignore invalid mutator
-	if len(engine.mutators) != 9 {
-		t.Errorf("Expected 9 mutators (all types enabled by default), got %d", len(engine.mutators))
+	if len(engine.mutators) != 10 {
+		t.Errorf("Expected 10 mutators (all types enabled by default), got %d", len(engine.mutators))
 	}
 }
 

--- a/internal/mutation/registry.go
+++ b/internal/mutation/registry.go
@@ -8,6 +8,7 @@ func getAllMutators() []Mutator {
 		&ArithmeticMutator{},
 		&BitwiseMutator{},
 		&BranchMutator{},
+		&BreakContinueMutator{},
 		&ConditionalMutator{},
 		&ErrorHandlingMutator{},
 		&InvertNegativesMutator{},


### PR DESCRIPTION
## Summary
- Add `BreakContinueMutator` that swaps `break` and `continue` branch statements
- Only label-less statements are mutated (labeled `break`/`continue` reference a specific loop/switch and swapping them is far more likely to be invalid)
- Auto-registered via `go generate`; integrated into the overlay apply pipeline

## Changes
- `internal/mutation/breakcontinue.go` — new mutator (`CanMutate` / `Mutate` / `Apply`)
- `internal/mutation/breakcontinue_test.go` — unit tests
- `internal/mutation/registry.go` — regenerated (8 mutators)
- `internal/mutation/engine_test.go` — updated expected mutator count and name list
- `internal/execution/overlay_test.go` + testdata — end-to-end golden test (`break` -> `continue`)
- `README.md` — documented the new mutation type

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (all packages pass)
- [x] `TestMutateAndApplyIntegration` covers `break` -> `continue`
- [x] `make lint` (pinned golangci-lint) clean

Closes #21
