### PR TITLE
feat: add loop condition mutation operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,9 @@ testdata/
 - Replace empty string literals with a non-empty placeholder
 - Import paths are never mutated
 
+### Loop Condition Mutations
+- Replace `for` loop conditions with `true` and `false`
+
 ## CI/CD Integration
 
 ### GitHub Actions

--- a/internal/execution/overlay_test.go
+++ b/internal/execution/overlay_test.go
@@ -92,6 +92,12 @@ var stringLiteralSrc string
 //go:embed testdata/stringliteral_empty.go
 var stringLiteralEmptySrc string
 
+//go:embed testdata/loopcondition.go
+var loopConditionSrc string
+
+//go:embed testdata/loopcondition_false.go
+var loopConditionFalseSrc string
+
 func TestNewOverlayMutator(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -798,6 +804,14 @@ func TestMutateAndApplyIntegration(t *testing.T) {
 			original:   `"hello"`,
 			mutated:    `""`,
 			want:       stringLiteralEmptySrc,
+		},
+		{
+			name:       "loop condition replaced with false",
+			src:        loopConditionSrc,
+			mutantType: "loop_condition",
+			original:   "i < n",
+			mutated:    "false",
+			want:       loopConditionFalseSrc,
 		},
 	}
 

--- a/internal/execution/testdata/loopcondition.go
+++ b/internal/execution/testdata/loopcondition.go
@@ -1,0 +1,9 @@
+package main
+
+func SumTo(n int) int {
+	total := 0
+	for i := 0; i < n; i++ {
+		total = total + i
+	}
+	return total
+}

--- a/internal/execution/testdata/loopcondition_false.go
+++ b/internal/execution/testdata/loopcondition_false.go
@@ -1,0 +1,9 @@
+package main
+
+func SumTo(n int) int {
+	total := 0
+	for i := 0; false; i++ {
+		total = total + i
+	}
+	return total
+}

--- a/internal/mutation/engine_test.go
+++ b/internal/mutation/engine_test.go
@@ -74,8 +74,8 @@ func TestNew(t *testing.T) {
 		t.Fatal("Expected engine to be non-nil")
 	}
 
-	if len(engine.mutators) != 12 {
-		t.Errorf("Expected 12 mutators, got %d", len(engine.mutators))
+	if len(engine.mutators) != 13 {
+		t.Errorf("Expected 13 mutators, got %d", len(engine.mutators))
 	}
 
 	// Check mutator types
@@ -85,7 +85,7 @@ func TestNew(t *testing.T) {
 		mutatorNames[mutator.Name()] = true
 	}
 
-	expectedMutators := []string{"arithmetic", "boundary_value", "branch", "break_continue", "conditional", "error_handling", "invert_negatives", "logical", "remove_self_assignments", "return", "string_literal"}
+	expectedMutators := []string{"arithmetic", "boundary_value", "branch", "break_continue", "conditional", "error_handling", "invert_negatives", "logical", "loop_condition", "remove_self_assignments", "return", "string_literal"}
 
 	for _, expected := range expectedMutators {
 		if !mutatorNames[expected] {
@@ -101,8 +101,8 @@ func TestNew_CustomMutators(t *testing.T) {
 		t.Fatalf("Failed to create mutation engine: %v", err)
 	}
 
-	if len(engine.mutators) != 12 {
-		t.Errorf("Expected 12 mutators (all types enabled by default), got %d", len(engine.mutators))
+	if len(engine.mutators) != 13 {
+		t.Errorf("Expected 13 mutators (all types enabled by default), got %d", len(engine.mutators))
 	}
 }
 
@@ -114,8 +114,8 @@ func TestNew_InvalidMutator(t *testing.T) {
 	}
 
 	// Should ignore invalid mutator
-	if len(engine.mutators) != 12 {
-		t.Errorf("Expected 12 mutators (all types enabled by default), got %d", len(engine.mutators))
+	if len(engine.mutators) != 13 {
+		t.Errorf("Expected 13 mutators (all types enabled by default), got %d", len(engine.mutators))
 	}
 }
 

--- a/internal/mutation/loopcondition.go
+++ b/internal/mutation/loopcondition.go
@@ -1,0 +1,83 @@
+package mutation
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+)
+
+const (
+	loopConditionMutatorName = "loop_condition"
+	loopConditionType        = "loop_condition"
+)
+
+// LoopConditionMutator mutates the condition of for statements to the boolean
+// literals true and false, testing whether loop termination is properly
+// covered by tests.
+type LoopConditionMutator struct {
+}
+
+// Name returns the name of the mutator.
+func (m *LoopConditionMutator) Name() string {
+	return loopConditionMutatorName
+}
+
+// CanMutate returns true if the node can be mutated by this mutator.
+func (m *LoopConditionMutator) CanMutate(node ast.Node) bool {
+	stmt, ok := node.(*ast.ForStmt)
+	if !ok || stmt.Cond == nil {
+		return false
+	}
+
+	return !isBoolLiteral(stmt.Cond)
+}
+
+// Mutate generates mutants for the given node.
+func (m *LoopConditionMutator) Mutate(node ast.Node, fset *token.FileSet) []Mutant {
+	stmt, ok := node.(*ast.ForStmt)
+	if !ok || stmt.Cond == nil || isBoolLiteral(stmt.Cond) {
+		return nil
+	}
+
+	pos := fset.Position(stmt.Pos())
+	original := exprToString(stmt.Cond)
+
+	return []Mutant{
+		{
+			Line:        pos.Line,
+			Column:      pos.Column,
+			Type:        loopConditionType,
+			Original:    original,
+			Mutated:     boolFalse,
+			Description: fmt.Sprintf("Replace loop condition %q with false", original),
+		},
+		{
+			Line:        pos.Line,
+			Column:      pos.Column,
+			Type:        loopConditionType,
+			Original:    original,
+			Mutated:     boolTrue,
+			Description: fmt.Sprintf("Replace loop condition %q with true", original),
+		},
+	}
+}
+
+// Apply applies the mutation to the given AST node.
+func (m *LoopConditionMutator) Apply(node ast.Node, mutant Mutant) bool {
+	if mutant.Type != loopConditionType {
+		return false
+	}
+
+	stmt, ok := node.(*ast.ForStmt)
+	if !ok || stmt.Cond == nil {
+		return false
+	}
+
+	if exprToString(stmt.Cond) != mutant.Original {
+		return false
+	}
+
+	stmt.Cond = &ast.Ident{Name: mutant.Mutated}
+
+	return true
+}

--- a/internal/mutation/loopcondition_test.go
+++ b/internal/mutation/loopcondition_test.go
@@ -1,0 +1,242 @@
+package mutation
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+func parseForStmt(t *testing.T, fset *token.FileSet, code string) ast.Node {
+	t.Helper()
+
+	src := "package main\nfunc test() {\n\t" + code + "\n}"
+
+	file, err := parser.ParseFile(fset, "test.go", src, 0)
+	if err != nil {
+		t.Fatalf("Failed to parse file: %v", err)
+	}
+
+	var stmt ast.Node
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		if fs, ok := n.(*ast.ForStmt); ok {
+			stmt = fs
+
+			return false
+		}
+
+		return true
+	})
+
+	if stmt == nil {
+		t.Fatalf("ForStmt not found in: %s", code)
+	}
+
+	return stmt
+}
+
+func TestLoopConditionMutator_Name(t *testing.T) {
+	t.Parallel()
+
+	mutator := &LoopConditionMutator{}
+	if mutator.Name() != loopConditionMutatorName {
+		t.Errorf("Expected name %q, got %s", loopConditionMutatorName, mutator.Name())
+	}
+}
+
+func TestLoopConditionMutator_CanMutate(t *testing.T) {
+	t.Parallel()
+
+	mutator := &LoopConditionMutator{}
+
+	tests := []struct {
+		name     string
+		code     string
+		expected bool
+	}{
+		{name: "for with condition", code: "for i := 0; i < n; i++ {\n}", expected: true},
+		{name: "for with only condition", code: "for i < n {\n}", expected: true},
+		{name: "infinite for", code: "for {\n}", expected: false},
+		{name: "for with true literal", code: "for true {\n}", expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			fset := token.NewFileSet()
+			stmt := parseForStmt(t, fset, tt.code)
+
+			if canMutate := mutator.CanMutate(stmt); canMutate != tt.expected {
+				t.Errorf("CanMutate() = %v, expected %v", canMutate, tt.expected)
+			}
+		})
+	}
+}
+
+func TestLoopConditionMutator_CanMutate_NonFor(t *testing.T) {
+	t.Parallel()
+
+	mutator := &LoopConditionMutator{}
+
+	expr, err := parser.ParseExpr("a + b")
+	if err != nil {
+		t.Fatalf("Failed to parse expression: %v", err)
+	}
+
+	if mutator.CanMutate(expr) {
+		t.Error("CanMutate() = true, want false for non-ForStmt node")
+	}
+}
+
+func TestLoopConditionMutator_Mutate(t *testing.T) {
+	t.Parallel()
+
+	mutator := &LoopConditionMutator{}
+	fset := token.NewFileSet()
+	stmt := parseForStmt(t, fset, "for i := 0; i < n; i++ {\n}")
+
+	mutants := mutator.Mutate(stmt, fset)
+
+	if len(mutants) != 2 {
+		t.Fatalf("Expected 2 mutants, got %d", len(mutants))
+	}
+
+	mutatedValues := make(map[string]bool)
+
+	for _, m := range mutants {
+		mutatedValues[m.Mutated] = true
+
+		if m.Type != loopConditionType {
+			t.Errorf("Type = %q, want %q", m.Type, loopConditionType)
+		}
+
+		if m.Original != "i < n" {
+			t.Errorf("Original = %q, want %q", m.Original, "i < n")
+		}
+
+		if m.Line <= 0 {
+			t.Errorf("Expected positive line number, got %d", m.Line)
+		}
+
+		if m.Description == "" {
+			t.Error("Expected non-empty description")
+		}
+	}
+
+	for _, want := range []string{"true", "false"} {
+		if !mutatedValues[want] {
+			t.Errorf("Expected mutation to %q not found", want)
+		}
+	}
+}
+
+func TestLoopConditionMutator_Mutate_Infinite(t *testing.T) {
+	t.Parallel()
+
+	mutator := &LoopConditionMutator{}
+	fset := token.NewFileSet()
+	stmt := parseForStmt(t, fset, "for {\n}")
+
+	if mutants := mutator.Mutate(stmt, fset); mutants != nil {
+		t.Errorf("Mutate() = %v, want nil for infinite loop", mutants)
+	}
+}
+
+func TestLoopConditionMutator_Apply(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		code       string
+		mutantType string
+		original   string
+		mutated    string
+		expected   bool
+		wantCond   string
+	}{
+		{
+			name:       "replace condition with false",
+			code:       "for i := 0; i < n; i++ {\n}",
+			mutantType: loopConditionType,
+			original:   "i < n",
+			mutated:    "false",
+			expected:   true,
+			wantCond:   "false",
+		},
+		{
+			name:       "replace condition with true",
+			code:       "for i < n {\n}",
+			mutantType: loopConditionType,
+			original:   "i < n",
+			mutated:    "true",
+			expected:   true,
+			wantCond:   "true",
+		},
+		{
+			name:       "wrong mutant type",
+			code:       "for i < n {\n}",
+			mutantType: "unknown",
+			original:   "i < n",
+			mutated:    "false",
+			expected:   false,
+			wantCond:   "i < n",
+		},
+		{
+			name:       "wrong original",
+			code:       "for i < n {\n}",
+			mutantType: loopConditionType,
+			original:   "i > n",
+			mutated:    "false",
+			expected:   false,
+			wantCond:   "i < n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mutator := &LoopConditionMutator{}
+			fset := token.NewFileSet()
+			stmt := parseForStmt(t, fset, tt.code)
+
+			mutant := Mutant{
+				Type:     tt.mutantType,
+				Original: tt.original,
+				Mutated:  tt.mutated,
+			}
+
+			if result := mutator.Apply(stmt, mutant); result != tt.expected {
+				t.Errorf("Apply() = %v, expected %v", result, tt.expected)
+			}
+
+			fs, ok := stmt.(*ast.ForStmt)
+			if !ok {
+				t.Fatalf("expected *ast.ForStmt, got %T", stmt)
+			}
+
+			if got := exprToString(fs.Cond); got != tt.wantCond {
+				t.Errorf("Cond = %q, want %q", got, tt.wantCond)
+			}
+		})
+	}
+}
+
+func TestLoopConditionMutator_Apply_NonForNode(t *testing.T) {
+	t.Parallel()
+
+	mutator := &LoopConditionMutator{}
+
+	expr, err := parser.ParseExpr("a + b")
+	if err != nil {
+		t.Fatalf("Failed to parse expression: %v", err)
+	}
+
+	mutant := Mutant{Type: loopConditionType, Original: "i < n", Mutated: "false"}
+
+	if mutator.Apply(expr, mutant) {
+		t.Error("Apply() = true, want false for non-ForStmt node")
+	}
+}

--- a/internal/mutation/registry.go
+++ b/internal/mutation/registry.go
@@ -14,6 +14,7 @@ func getAllMutators() []Mutator {
 		&ErrorHandlingMutator{},
 		&InvertNegativesMutator{},
 		&LogicalMutator{},
+		&LoopConditionMutator{},
 		&RemoveSelfAssignmentsMutator{},
 		&ReturnMutator{},
 		&StringLiteralMutator{},


### PR DESCRIPTION
## Summary
- Add `LoopConditionMutator` that replaces `for` loop conditions with `true` and `false`
- `false` makes the loop body never execute; `true` removes the termination check (mirrors the existing `BranchMutator` which does the same for `if`)
- Infinite loops (`for {}`) and loops whose condition is already a bool literal are skipped

## Changes
- `internal/mutation/loopcondition.go` — new mutator
- `internal/mutation/loopcondition_test.go` — unit tests
- `internal/mutation/registry.go` — regenerated (8 mutators)
- `internal/mutation/engine_test.go` — updated mutator count/list
- `internal/execution/overlay_test.go` + testdata — end-to-end golden test (`i < n` -> `false`)
- `README.md` — documented the new mutation type

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...`
- [x] `TestMutateAndApplyIntegration` covers `i < n` -> `false`
- [x] `make lint` (pinned golangci-lint) reports 0 issues

Closes #22
