### PR TITLE
feat: add assignment removal mutation operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,9 @@ testdata/
 ### Empty Block Mutations
 - Remove all statements inside a block (e.g. `{ ... }` becomes `{}`)
 
+### Assignment Removal Mutations
+- Remove assignment statements (`=`, `+=`, ...; short variable declarations `:=` are not targeted)
+
 ## CI/CD Integration
 
 ### GitHub Actions

--- a/internal/execution/overlay_test.go
+++ b/internal/execution/overlay_test.go
@@ -104,6 +104,12 @@ var emptyBlockSrc string
 //go:embed testdata/emptyblock_empty.go
 var emptyBlockEmptySrc string
 
+//go:embed testdata/assignremoval.go
+var assignRemovalSrc string
+
+//go:embed testdata/assignremoval_removed.go
+var assignRemovalRemovedSrc string
+
 func TestNewOverlayMutator(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -826,6 +832,14 @@ func TestMutateAndApplyIntegration(t *testing.T) {
 			original:   "{...}",
 			mutated:    "{}",
 			want:       emptyBlockEmptySrc,
+		},
+		{
+			name:       "assignment statement removed",
+			src:        assignRemovalSrc,
+			mutantType: "assignment_removal",
+			original:   "total",
+			mutated:    "<removed>",
+			want:       assignRemovalRemovedSrc,
 		},
 	}
 

--- a/internal/execution/testdata/assignremoval.go
+++ b/internal/execution/testdata/assignremoval.go
@@ -1,0 +1,7 @@
+package main
+
+func Accumulate(a, b int) int {
+	total := a
+	total = total + b
+	return total
+}

--- a/internal/execution/testdata/assignremoval_removed.go
+++ b/internal/execution/testdata/assignremoval_removed.go
@@ -1,0 +1,7 @@
+package main
+
+func Accumulate(a, b int) int {
+	total := a
+
+	return total
+}

--- a/internal/mutation/assignmentremoval.go
+++ b/internal/mutation/assignmentremoval.go
@@ -1,0 +1,78 @@
+package mutation
+
+import (
+	"go/ast"
+	"go/token"
+)
+
+const (
+	assignmentRemovalMutatorName = "assignment_removal"
+	assignmentRemovalType        = "assignment_removal"
+
+	assignmentRemovalMutated = "<removed>"
+)
+
+// AssignmentRemovalMutator removes assignment statements, testing whether the
+// effect of the assignment is properly covered by tests.
+//
+// Short variable declarations (`:=`) are not targeted because removing them
+// leaves later references undefined, which never compiles.
+type AssignmentRemovalMutator struct {
+}
+
+// Name returns the name of the mutator.
+func (m *AssignmentRemovalMutator) Name() string {
+	return assignmentRemovalMutatorName
+}
+
+// CanMutate returns true if the node can be mutated by this mutator.
+func (m *AssignmentRemovalMutator) CanMutate(node ast.Node) bool {
+	stmt, ok := node.(*ast.AssignStmt)
+
+	return ok && stmt.Tok != token.DEFINE
+}
+
+// Mutate generates mutants for the given node.
+func (m *AssignmentRemovalMutator) Mutate(node ast.Node, fset *token.FileSet) []Mutant {
+	stmt, ok := node.(*ast.AssignStmt)
+	if !ok || stmt.Tok == token.DEFINE {
+		return nil
+	}
+
+	pos := fset.Position(stmt.Pos())
+
+	return []Mutant{
+		{
+			Line:        pos.Line,
+			Column:      pos.Column,
+			Type:        assignmentRemovalType,
+			Original:    exprToString(stmt.Lhs[0]),
+			Mutated:     assignmentRemovalMutated,
+			Description: "Remove assignment statement",
+		},
+	}
+}
+
+// Apply applies the mutation to the given AST node.
+// Assignment removal requires node replacement via the cursor, so the plain
+// Apply path always reports failure.
+func (m *AssignmentRemovalMutator) Apply(_ ast.Node, _ Mutant) bool {
+	return false
+}
+
+// ApplyWithCursor removes the assignment statement by replacing it with an
+// empty statement.
+func (m *AssignmentRemovalMutator) ApplyWithCursor(node ast.Node, replaceFunc func(ast.Node), mutant Mutant) bool {
+	if mutant.Type != assignmentRemovalType {
+		return false
+	}
+
+	stmt, ok := node.(*ast.AssignStmt)
+	if !ok || stmt.Tok == token.DEFINE {
+		return false
+	}
+
+	replaceFunc(&ast.EmptyStmt{})
+
+	return true
+}

--- a/internal/mutation/assignmentremoval_test.go
+++ b/internal/mutation/assignmentremoval_test.go
@@ -1,0 +1,237 @@
+package mutation
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+func parseAssignStmtForRemoval(t *testing.T, fset *token.FileSet, code string) ast.Node {
+	t.Helper()
+
+	src := "package main\nfunc test() {\n\t" + code + "\n}"
+
+	file, err := parser.ParseFile(fset, "test.go", src, 0)
+	if err != nil {
+		t.Fatalf("Failed to parse file: %v", err)
+	}
+
+	var stmt ast.Node
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		if as, ok := n.(*ast.AssignStmt); ok {
+			stmt = as
+
+			return false
+		}
+
+		return true
+	})
+
+	if stmt == nil {
+		t.Fatalf("AssignStmt not found in: %s", code)
+	}
+
+	return stmt
+}
+
+func TestAssignmentRemovalMutator_Name(t *testing.T) {
+	t.Parallel()
+
+	mutator := &AssignmentRemovalMutator{}
+	if mutator.Name() != assignmentRemovalMutatorName {
+		t.Errorf("Expected name %q, got %s", assignmentRemovalMutatorName, mutator.Name())
+	}
+}
+
+func TestAssignmentRemovalMutator_CanMutate(t *testing.T) {
+	t.Parallel()
+
+	mutator := &AssignmentRemovalMutator{}
+
+	tests := []struct {
+		name     string
+		code     string
+		expected bool
+	}{
+		{name: "simple assign", code: "a = b", expected: true},
+		{name: "compound assign", code: "a += b", expected: true},
+		{name: "multi assign", code: "a, b = b, a", expected: true},
+		{name: "short var decl", code: "a := b", expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			fset := token.NewFileSet()
+			stmt := parseAssignStmtForRemoval(t, fset, tt.code)
+
+			if canMutate := mutator.CanMutate(stmt); canMutate != tt.expected {
+				t.Errorf("CanMutate() = %v, expected %v", canMutate, tt.expected)
+			}
+		})
+	}
+}
+
+func TestAssignmentRemovalMutator_CanMutate_NonAssign(t *testing.T) {
+	t.Parallel()
+
+	mutator := &AssignmentRemovalMutator{}
+
+	expr, err := parser.ParseExpr("a + b")
+	if err != nil {
+		t.Fatalf("Failed to parse expression: %v", err)
+	}
+
+	if mutator.CanMutate(expr) {
+		t.Error("CanMutate() = true, want false for non-AssignStmt node")
+	}
+}
+
+func TestAssignmentRemovalMutator_Mutate(t *testing.T) {
+	t.Parallel()
+
+	mutator := &AssignmentRemovalMutator{}
+	fset := token.NewFileSet()
+	stmt := parseAssignStmtForRemoval(t, fset, "total = total + b")
+
+	mutants := mutator.Mutate(stmt, fset)
+
+	if len(mutants) != 1 {
+		t.Fatalf("Expected 1 mutant, got %d", len(mutants))
+	}
+
+	m := mutants[0]
+
+	if m.Type != assignmentRemovalType {
+		t.Errorf("Type = %q, want %q", m.Type, assignmentRemovalType)
+	}
+
+	if m.Original != "total" {
+		t.Errorf("Original = %q, want %q", m.Original, "total")
+	}
+
+	if m.Mutated != assignmentRemovalMutated {
+		t.Errorf("Mutated = %q, want %q", m.Mutated, assignmentRemovalMutated)
+	}
+
+	if m.Line <= 0 {
+		t.Errorf("Expected positive line number, got %d", m.Line)
+	}
+
+	if m.Description == "" {
+		t.Error("Expected non-empty description")
+	}
+}
+
+func TestAssignmentRemovalMutator_Mutate_Define(t *testing.T) {
+	t.Parallel()
+
+	mutator := &AssignmentRemovalMutator{}
+	fset := token.NewFileSet()
+	stmt := parseAssignStmtForRemoval(t, fset, "a := b")
+
+	if mutants := mutator.Mutate(stmt, fset); mutants != nil {
+		t.Errorf("Mutate() = %v, want nil for short var decl", mutants)
+	}
+}
+
+func TestAssignmentRemovalMutator_Apply_AlwaysFalse(t *testing.T) {
+	t.Parallel()
+
+	mutator := &AssignmentRemovalMutator{}
+	fset := token.NewFileSet()
+	stmt := parseAssignStmtForRemoval(t, fset, "a = b")
+
+	mutant := Mutant{Type: assignmentRemovalType, Original: "a", Mutated: assignmentRemovalMutated}
+
+	if mutator.Apply(stmt, mutant) {
+		t.Error("Apply() = true, want false (removal requires cursor)")
+	}
+}
+
+func TestAssignmentRemovalMutator_ApplyWithCursor(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		code        string
+		mutantType  string
+		expected    bool
+		wantReplace bool
+	}{
+		{
+			name:        "removes simple assignment",
+			code:        "a = b",
+			mutantType:  assignmentRemovalType,
+			expected:    true,
+			wantReplace: true,
+		},
+		{
+			name:        "wrong mutant type",
+			code:        "a = b",
+			mutantType:  "unknown",
+			expected:    false,
+			wantReplace: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mutator := &AssignmentRemovalMutator{}
+			fset := token.NewFileSet()
+			stmt := parseAssignStmtForRemoval(t, fset, tt.code)
+
+			replaced := false
+
+			var replacement ast.Node
+
+			replaceFunc := func(n ast.Node) {
+				replaced = true
+				replacement = n
+			}
+
+			mutant := Mutant{Type: tt.mutantType, Original: "a", Mutated: assignmentRemovalMutated}
+
+			if result := mutator.ApplyWithCursor(stmt, replaceFunc, mutant); result != tt.expected {
+				t.Errorf("ApplyWithCursor() = %v, expected %v", result, tt.expected)
+			}
+
+			if replaced != tt.wantReplace {
+				t.Errorf("replaceFunc called = %v, want %v", replaced, tt.wantReplace)
+			}
+
+			if tt.wantReplace {
+				if _, ok := replacement.(*ast.EmptyStmt); !ok {
+					t.Errorf("replacement = %T, want *ast.EmptyStmt", replacement)
+				}
+			}
+		})
+	}
+}
+
+func TestAssignmentRemovalMutator_ApplyWithCursor_NonAssign(t *testing.T) {
+	t.Parallel()
+
+	mutator := &AssignmentRemovalMutator{}
+
+	expr, err := parser.ParseExpr("a + b")
+	if err != nil {
+		t.Fatalf("Failed to parse expression: %v", err)
+	}
+
+	called := false
+	mutant := Mutant{Type: assignmentRemovalType, Original: "a", Mutated: assignmentRemovalMutated}
+
+	if mutator.ApplyWithCursor(expr, func(ast.Node) { called = true }, mutant) {
+		t.Error("ApplyWithCursor() = true, want false for non-AssignStmt node")
+	}
+
+	if called {
+		t.Error("replaceFunc should not be called for non-AssignStmt node")
+	}
+}

--- a/internal/mutation/engine_test.go
+++ b/internal/mutation/engine_test.go
@@ -74,8 +74,8 @@ func TestNew(t *testing.T) {
 		t.Fatal("Expected engine to be non-nil")
 	}
 
-	if len(engine.mutators) != 14 {
-		t.Errorf("Expected 14 mutators, got %d", len(engine.mutators))
+	if len(engine.mutators) != 15 {
+		t.Errorf("Expected 15 mutators, got %d", len(engine.mutators))
 	}
 
 	// Check mutator types
@@ -85,7 +85,7 @@ func TestNew(t *testing.T) {
 		mutatorNames[mutator.Name()] = true
 	}
 
-	expectedMutators := []string{"arithmetic", "boundary_value", "branch", "break_continue", "conditional", "empty_block", "error_handling", "invert_negatives", "logical", "loop_condition", "remove_self_assignments", "return", "string_literal"}
+	expectedMutators := []string{"arithmetic", "assignment_removal", "boundary_value", "branch", "break_continue", "conditional", "empty_block", "error_handling", "invert_negatives", "logical", "loop_condition", "remove_self_assignments", "return", "string_literal"}
 
 	for _, expected := range expectedMutators {
 		if !mutatorNames[expected] {
@@ -101,8 +101,8 @@ func TestNew_CustomMutators(t *testing.T) {
 		t.Fatalf("Failed to create mutation engine: %v", err)
 	}
 
-	if len(engine.mutators) != 14 {
-		t.Errorf("Expected 14 mutators (all types enabled by default), got %d", len(engine.mutators))
+	if len(engine.mutators) != 15 {
+		t.Errorf("Expected 15 mutators (all types enabled by default), got %d", len(engine.mutators))
 	}
 }
 
@@ -114,8 +114,8 @@ func TestNew_InvalidMutator(t *testing.T) {
 	}
 
 	// Should ignore invalid mutator
-	if len(engine.mutators) != 14 {
-		t.Errorf("Expected 14 mutators (all types enabled by default), got %d", len(engine.mutators))
+	if len(engine.mutators) != 15 {
+		t.Errorf("Expected 15 mutators (all types enabled by default), got %d", len(engine.mutators))
 	}
 }
 

--- a/internal/mutation/registry.go
+++ b/internal/mutation/registry.go
@@ -6,6 +6,7 @@ package mutation
 func getAllMutators() []Mutator {
 	return []Mutator{
 		&ArithmeticMutator{},
+		&AssignmentRemovalMutator{},
 		&BitwiseMutator{},
 		&BoundaryValueMutator{},
 		&BranchMutator{},


### PR DESCRIPTION
## Summary
- Add `AssignmentRemovalMutator` that removes assignment statements (replaces them with an empty statement)
- Targets `=` and compound assignments (`+=`, `-=`, ...); short variable declarations (`:=`) are skipped because removing them leaves later references undefined (never compiles)
- Uses the `CursorApplier` interface for node replacement (same mechanism as logical NOT removal)

## Disambiguation from related issues
This is one of three statement-removal operators. To avoid duplicate mutants, the removal operators are partitioned by node type:
- #19 (this PR) removes `*ast.AssignStmt`
- #20 removes `*ast.ExprStmt`
- #6 removes the remaining removable statements (inc/dec, defer, go, send)

## Changes
- `internal/mutation/assignmentremoval.go` — new mutator
- `internal/mutation/assignmentremoval_test.go` — unit tests (incl. `ApplyWithCursor`)
- `internal/mutation/registry.go` — regenerated (8 mutators)
- `internal/mutation/engine_test.go` — updated mutator count/list
- `internal/execution/overlay_test.go` + testdata — end-to-end golden test
- `README.md` — documented the new mutation type

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...`
- [x] `TestMutateAndApplyIntegration` covers removing `total = total + b`
- [x] `make lint` (pinned golangci-lint) reports 0 issues

Closes #19
