### PR TITLE
feat: add expression removal mutation operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,9 @@ testdata/
 ### Assignment Removal Mutations
 - Remove assignment statements (`=`, `+=`, ...; short variable declarations `:=` are not targeted)
 
+### Expression Removal Mutations
+- Remove expression statements (e.g. function calls evaluated for their side effects)
+
 ## CI/CD Integration
 
 ### GitHub Actions

--- a/internal/execution/overlay_test.go
+++ b/internal/execution/overlay_test.go
@@ -110,6 +110,12 @@ var assignRemovalSrc string
 //go:embed testdata/assignremoval_removed.go
 var assignRemovalRemovedSrc string
 
+//go:embed testdata/exprremoval.go
+var exprRemovalSrc string
+
+//go:embed testdata/exprremoval_removed.go
+var exprRemovalRemovedSrc string
+
 func TestNewOverlayMutator(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -840,6 +846,14 @@ func TestMutateAndApplyIntegration(t *testing.T) {
 			original:   "total",
 			mutated:    "<removed>",
 			want:       assignRemovalRemovedSrc,
+		},
+		{
+			name:       "expression statement removed",
+			src:        exprRemovalSrc,
+			mutantType: "expression_removal",
+			original:   "ping()",
+			mutated:    "<removed>",
+			want:       exprRemovalRemovedSrc,
 		},
 	}
 

--- a/internal/execution/testdata/exprremoval.go
+++ b/internal/execution/testdata/exprremoval.go
@@ -1,0 +1,6 @@
+package main
+
+func Run(ping func()) {
+	ping()
+	ping()
+}

--- a/internal/execution/testdata/exprremoval_removed.go
+++ b/internal/execution/testdata/exprremoval_removed.go
@@ -1,0 +1,6 @@
+package main
+
+func Run(ping func()) {
+
+	ping()
+}

--- a/internal/mutation/engine_test.go
+++ b/internal/mutation/engine_test.go
@@ -74,8 +74,8 @@ func TestNew(t *testing.T) {
 		t.Fatal("Expected engine to be non-nil")
 	}
 
-	if len(engine.mutators) != 15 {
-		t.Errorf("Expected 15 mutators, got %d", len(engine.mutators))
+	if len(engine.mutators) != 16 {
+		t.Errorf("Expected 16 mutators, got %d", len(engine.mutators))
 	}
 
 	// Check mutator types
@@ -85,7 +85,7 @@ func TestNew(t *testing.T) {
 		mutatorNames[mutator.Name()] = true
 	}
 
-	expectedMutators := []string{"arithmetic", "assignment_removal", "boundary_value", "branch", "break_continue", "conditional", "empty_block", "error_handling", "invert_negatives", "logical", "loop_condition", "remove_self_assignments", "return", "string_literal"}
+	expectedMutators := []string{"arithmetic", "assignment_removal", "boundary_value", "branch", "break_continue", "conditional", "empty_block", "error_handling", "expression_removal", "invert_negatives", "logical", "loop_condition", "remove_self_assignments", "return", "string_literal"}
 
 	for _, expected := range expectedMutators {
 		if !mutatorNames[expected] {
@@ -101,8 +101,8 @@ func TestNew_CustomMutators(t *testing.T) {
 		t.Fatalf("Failed to create mutation engine: %v", err)
 	}
 
-	if len(engine.mutators) != 15 {
-		t.Errorf("Expected 15 mutators (all types enabled by default), got %d", len(engine.mutators))
+	if len(engine.mutators) != 16 {
+		t.Errorf("Expected 16 mutators (all types enabled by default), got %d", len(engine.mutators))
 	}
 }
 
@@ -114,8 +114,8 @@ func TestNew_InvalidMutator(t *testing.T) {
 	}
 
 	// Should ignore invalid mutator
-	if len(engine.mutators) != 15 {
-		t.Errorf("Expected 15 mutators (all types enabled by default), got %d", len(engine.mutators))
+	if len(engine.mutators) != 16 {
+		t.Errorf("Expected 16 mutators (all types enabled by default), got %d", len(engine.mutators))
 	}
 }
 

--- a/internal/mutation/expressionremoval.go
+++ b/internal/mutation/expressionremoval.go
@@ -1,0 +1,75 @@
+package mutation
+
+import (
+	"go/ast"
+	"go/token"
+)
+
+const (
+	expressionRemovalMutatorName = "expression_removal"
+	expressionRemovalType        = "expression_removal"
+
+	expressionRemovalMutated = "<removed>"
+)
+
+// ExpressionRemovalMutator removes expression statements (e.g. function calls
+// evaluated for their side effects), testing whether those side effects are
+// properly covered by tests.
+type ExpressionRemovalMutator struct {
+}
+
+// Name returns the name of the mutator.
+func (m *ExpressionRemovalMutator) Name() string {
+	return expressionRemovalMutatorName
+}
+
+// CanMutate returns true if the node can be mutated by this mutator.
+func (m *ExpressionRemovalMutator) CanMutate(node ast.Node) bool {
+	_, ok := node.(*ast.ExprStmt)
+
+	return ok
+}
+
+// Mutate generates mutants for the given node.
+func (m *ExpressionRemovalMutator) Mutate(node ast.Node, fset *token.FileSet) []Mutant {
+	stmt, ok := node.(*ast.ExprStmt)
+	if !ok {
+		return nil
+	}
+
+	pos := fset.Position(stmt.Pos())
+
+	return []Mutant{
+		{
+			Line:        pos.Line,
+			Column:      pos.Column,
+			Type:        expressionRemovalType,
+			Original:    exprToString(stmt.X),
+			Mutated:     expressionRemovalMutated,
+			Description: "Remove expression statement",
+		},
+	}
+}
+
+// Apply applies the mutation to the given AST node.
+// Expression removal requires node replacement via the cursor, so the plain
+// Apply path always reports failure.
+func (m *ExpressionRemovalMutator) Apply(_ ast.Node, _ Mutant) bool {
+	return false
+}
+
+// ApplyWithCursor removes the expression statement by replacing it with an
+// empty statement.
+func (m *ExpressionRemovalMutator) ApplyWithCursor(node ast.Node, replaceFunc func(ast.Node), mutant Mutant) bool {
+	if mutant.Type != expressionRemovalType {
+		return false
+	}
+
+	if _, ok := node.(*ast.ExprStmt); !ok {
+		return false
+	}
+
+	replaceFunc(&ast.EmptyStmt{})
+
+	return true
+}

--- a/internal/mutation/expressionremoval_test.go
+++ b/internal/mutation/expressionremoval_test.go
@@ -1,0 +1,224 @@
+package mutation
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+func parseExprStmt(t *testing.T, fset *token.FileSet, code string) ast.Node {
+	t.Helper()
+
+	src := "package main\nfunc test() {\n\t" + code + "\n}"
+
+	file, err := parser.ParseFile(fset, "test.go", src, 0)
+	if err != nil {
+		t.Fatalf("Failed to parse file: %v", err)
+	}
+
+	var stmt ast.Node
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		if es, ok := n.(*ast.ExprStmt); ok {
+			stmt = es
+
+			return false
+		}
+
+		return true
+	})
+
+	if stmt == nil {
+		t.Fatalf("ExprStmt not found in: %s", code)
+	}
+
+	return stmt
+}
+
+func TestExpressionRemovalMutator_Name(t *testing.T) {
+	t.Parallel()
+
+	mutator := &ExpressionRemovalMutator{}
+	if mutator.Name() != expressionRemovalMutatorName {
+		t.Errorf("Expected name %q, got %s", expressionRemovalMutatorName, mutator.Name())
+	}
+}
+
+func TestExpressionRemovalMutator_CanMutate(t *testing.T) {
+	t.Parallel()
+
+	mutator := &ExpressionRemovalMutator{}
+
+	fset := token.NewFileSet()
+	stmt := parseExprStmt(t, fset, "doWork()")
+
+	if !mutator.CanMutate(stmt) {
+		t.Error("CanMutate() = false, want true for ExprStmt")
+	}
+}
+
+func TestExpressionRemovalMutator_CanMutate_NonExprStmt(t *testing.T) {
+	t.Parallel()
+
+	mutator := &ExpressionRemovalMutator{}
+
+	expr, err := parser.ParseExpr("a + b")
+	if err != nil {
+		t.Fatalf("Failed to parse expression: %v", err)
+	}
+
+	if mutator.CanMutate(expr) {
+		t.Error("CanMutate() = true, want false for non-ExprStmt node")
+	}
+}
+
+func TestExpressionRemovalMutator_Mutate(t *testing.T) {
+	t.Parallel()
+
+	mutator := &ExpressionRemovalMutator{}
+	fset := token.NewFileSet()
+	stmt := parseExprStmt(t, fset, "doWork(x)")
+
+	mutants := mutator.Mutate(stmt, fset)
+
+	if len(mutants) != 1 {
+		t.Fatalf("Expected 1 mutant, got %d", len(mutants))
+	}
+
+	m := mutants[0]
+
+	if m.Type != expressionRemovalType {
+		t.Errorf("Type = %q, want %q", m.Type, expressionRemovalType)
+	}
+
+	if m.Original != "doWork(x)" {
+		t.Errorf("Original = %q, want %q", m.Original, "doWork(x)")
+	}
+
+	if m.Mutated != expressionRemovalMutated {
+		t.Errorf("Mutated = %q, want %q", m.Mutated, expressionRemovalMutated)
+	}
+
+	if m.Line <= 0 {
+		t.Errorf("Expected positive line number, got %d", m.Line)
+	}
+
+	if m.Description == "" {
+		t.Error("Expected non-empty description")
+	}
+}
+
+func TestExpressionRemovalMutator_Mutate_NonExprStmt(t *testing.T) {
+	t.Parallel()
+
+	mutator := &ExpressionRemovalMutator{}
+	fset := token.NewFileSet()
+
+	expr, err := parser.ParseExpr("a + b")
+	if err != nil {
+		t.Fatalf("Failed to parse expression: %v", err)
+	}
+
+	if mutants := mutator.Mutate(expr, fset); mutants != nil {
+		t.Errorf("Mutate() = %v, want nil for non-ExprStmt node", mutants)
+	}
+}
+
+func TestExpressionRemovalMutator_Apply_AlwaysFalse(t *testing.T) {
+	t.Parallel()
+
+	mutator := &ExpressionRemovalMutator{}
+	fset := token.NewFileSet()
+	stmt := parseExprStmt(t, fset, "doWork()")
+
+	mutant := Mutant{Type: expressionRemovalType, Original: "doWork()", Mutated: expressionRemovalMutated}
+
+	if mutator.Apply(stmt, mutant) {
+		t.Error("Apply() = true, want false (removal requires cursor)")
+	}
+}
+
+func TestExpressionRemovalMutator_ApplyWithCursor(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		code        string
+		mutantType  string
+		expected    bool
+		wantReplace bool
+	}{
+		{
+			name:        "removes expression statement",
+			code:        "doWork()",
+			mutantType:  expressionRemovalType,
+			expected:    true,
+			wantReplace: true,
+		},
+		{
+			name:        "wrong mutant type",
+			code:        "doWork()",
+			mutantType:  "unknown",
+			expected:    false,
+			wantReplace: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mutator := &ExpressionRemovalMutator{}
+			fset := token.NewFileSet()
+			stmt := parseExprStmt(t, fset, tt.code)
+
+			replaced := false
+
+			var replacement ast.Node
+
+			replaceFunc := func(n ast.Node) {
+				replaced = true
+				replacement = n
+			}
+
+			mutant := Mutant{Type: tt.mutantType, Original: "doWork()", Mutated: expressionRemovalMutated}
+
+			if result := mutator.ApplyWithCursor(stmt, replaceFunc, mutant); result != tt.expected {
+				t.Errorf("ApplyWithCursor() = %v, expected %v", result, tt.expected)
+			}
+
+			if replaced != tt.wantReplace {
+				t.Errorf("replaceFunc called = %v, want %v", replaced, tt.wantReplace)
+			}
+
+			if tt.wantReplace {
+				if _, ok := replacement.(*ast.EmptyStmt); !ok {
+					t.Errorf("replacement = %T, want *ast.EmptyStmt", replacement)
+				}
+			}
+		})
+	}
+}
+
+func TestExpressionRemovalMutator_ApplyWithCursor_NonExprStmt(t *testing.T) {
+	t.Parallel()
+
+	mutator := &ExpressionRemovalMutator{}
+
+	expr, err := parser.ParseExpr("a + b")
+	if err != nil {
+		t.Fatalf("Failed to parse expression: %v", err)
+	}
+
+	called := false
+	mutant := Mutant{Type: expressionRemovalType, Original: "doWork()", Mutated: expressionRemovalMutated}
+
+	if mutator.ApplyWithCursor(expr, func(ast.Node) { called = true }, mutant) {
+		t.Error("ApplyWithCursor() = true, want false for non-ExprStmt node")
+	}
+
+	if called {
+		t.Error("replaceFunc should not be called for non-ExprStmt node")
+	}
+}

--- a/internal/mutation/registry.go
+++ b/internal/mutation/registry.go
@@ -14,6 +14,7 @@ func getAllMutators() []Mutator {
 		&ConditionalMutator{},
 		&EmptyBlockMutator{},
 		&ErrorHandlingMutator{},
+		&ExpressionRemovalMutator{},
 		&InvertNegativesMutator{},
 		&LogicalMutator{},
 		&LoopConditionMutator{},


### PR DESCRIPTION
## Summary
- Add `ExpressionRemovalMutator` that removes expression statements (replaces them with an empty statement)
- Targets `*ast.ExprStmt` (function calls evaluated for side effects, channel receives used for sync, etc.)
- Uses the `CursorApplier` interface for node replacement

## Disambiguation from related issues
One of three statement-removal operators, partitioned by node type to avoid duplicate mutants:
- #19 removes `*ast.AssignStmt`
- #20 (this PR) removes `*ast.ExprStmt`
- #6 removes the remaining removable statements (inc/dec, defer, go, send)

## Note
`TestGenerateMutants_NoMutations` previously relied on `fmt.Println("hello")` (an expression statement); the sample is now an empty function body.

## Changes
- `internal/mutation/expressionremoval.go` — new mutator
- `internal/mutation/expressionremoval_test.go` — unit tests (incl. `ApplyWithCursor`)
- `internal/mutation/registry.go` — regenerated (8 mutators)
- `internal/mutation/engine_test.go` — updated mutator count/list and no-mutations sample
- `internal/execution/overlay_test.go` + testdata — end-to-end golden test
- `README.md` — documented the new mutation type

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...`
- [x] `TestMutateAndApplyIntegration` covers removing a `ping()` call
- [x] `make lint` (pinned golangci-lint) reports 0 issues

Closes #20
