### PR TITLE
feat: add statement removal mutation operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,9 @@ testdata/
 ### Expression Removal Mutations
 - Remove expression statements (e.g. function calls evaluated for their side effects)
 
+### Statement Removal Mutations
+- Remove increment/decrement (`i++`, `i--`), `defer`, `go`, and channel send (`ch <- v`) statements
+
 ## CI/CD Integration
 
 ### GitHub Actions

--- a/internal/execution/overlay_test.go
+++ b/internal/execution/overlay_test.go
@@ -116,6 +116,12 @@ var exprRemovalSrc string
 //go:embed testdata/exprremoval_removed.go
 var exprRemovalRemovedSrc string
 
+//go:embed testdata/stmtremoval.go
+var stmtRemovalSrc string
+
+//go:embed testdata/stmtremoval_removed.go
+var stmtRemovalRemovedSrc string
+
 func TestNewOverlayMutator(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -854,6 +860,14 @@ func TestMutateAndApplyIntegration(t *testing.T) {
 			original:   "ping()",
 			mutated:    "<removed>",
 			want:       exprRemovalRemovedSrc,
+		},
+		{
+			name:       "statement removed",
+			src:        stmtRemovalSrc,
+			mutantType: "statement_removal",
+			original:   "*counter++",
+			mutated:    "<removed>",
+			want:       stmtRemovalRemovedSrc,
 		},
 	}
 

--- a/internal/execution/testdata/stmtremoval.go
+++ b/internal/execution/testdata/stmtremoval.go
@@ -1,0 +1,6 @@
+package main
+
+func Inc(counter *int) {
+	*counter++
+	*counter++
+}

--- a/internal/execution/testdata/stmtremoval_removed.go
+++ b/internal/execution/testdata/stmtremoval_removed.go
@@ -1,0 +1,6 @@
+package main
+
+func Inc(counter *int) {
+
+	*counter++
+}

--- a/internal/mutation/engine_test.go
+++ b/internal/mutation/engine_test.go
@@ -74,8 +74,8 @@ func TestNew(t *testing.T) {
 		t.Fatal("Expected engine to be non-nil")
 	}
 
-	if len(engine.mutators) != 16 {
-		t.Errorf("Expected 16 mutators, got %d", len(engine.mutators))
+	if len(engine.mutators) != 17 {
+		t.Errorf("Expected 17 mutators, got %d", len(engine.mutators))
 	}
 
 	// Check mutator types
@@ -85,7 +85,7 @@ func TestNew(t *testing.T) {
 		mutatorNames[mutator.Name()] = true
 	}
 
-	expectedMutators := []string{"arithmetic", "assignment_removal", "boundary_value", "branch", "break_continue", "conditional", "empty_block", "error_handling", "expression_removal", "invert_negatives", "logical", "loop_condition", "remove_self_assignments", "return", "string_literal"}
+	expectedMutators := []string{"arithmetic", "assignment_removal", "boundary_value", "branch", "break_continue", "conditional", "empty_block", "error_handling", "expression_removal", "invert_negatives", "logical", "loop_condition", "remove_self_assignments", "return", "statement_removal", "string_literal"}
 
 	for _, expected := range expectedMutators {
 		if !mutatorNames[expected] {
@@ -101,8 +101,8 @@ func TestNew_CustomMutators(t *testing.T) {
 		t.Fatalf("Failed to create mutation engine: %v", err)
 	}
 
-	if len(engine.mutators) != 16 {
-		t.Errorf("Expected 16 mutators (all types enabled by default), got %d", len(engine.mutators))
+	if len(engine.mutators) != 17 {
+		t.Errorf("Expected 17 mutators (all types enabled by default), got %d", len(engine.mutators))
 	}
 }
 
@@ -114,8 +114,8 @@ func TestNew_InvalidMutator(t *testing.T) {
 	}
 
 	// Should ignore invalid mutator
-	if len(engine.mutators) != 16 {
-		t.Errorf("Expected 16 mutators (all types enabled by default), got %d", len(engine.mutators))
+	if len(engine.mutators) != 17 {
+		t.Errorf("Expected 17 mutators (all types enabled by default), got %d", len(engine.mutators))
 	}
 }
 

--- a/internal/mutation/registry.go
+++ b/internal/mutation/registry.go
@@ -20,6 +20,7 @@ func getAllMutators() []Mutator {
 		&LoopConditionMutator{},
 		&RemoveSelfAssignmentsMutator{},
 		&ReturnMutator{},
+		&StatementRemovalMutator{},
 		&StringLiteralMutator{},
 	}
 }

--- a/internal/mutation/statementremoval.go
+++ b/internal/mutation/statementremoval.go
@@ -1,0 +1,98 @@
+package mutation
+
+import (
+	"go/ast"
+	"go/printer"
+	"go/token"
+	"strings"
+)
+
+const (
+	statementRemovalMutatorName = "statement_removal"
+	statementRemovalType        = "statement_removal"
+
+	statementRemovalMutated = "<removed>"
+)
+
+// StatementRemovalMutator removes standalone statements that carry a side
+// effect, testing whether that side effect is covered by tests.
+//
+// To avoid generating duplicate mutants, assignment statements and expression
+// statements are handled by the dedicated assignment_removal and
+// expression_removal mutators; this mutator covers the remaining removable
+// statement kinds: increment/decrement, defer, go, and channel send.
+type StatementRemovalMutator struct {
+}
+
+// Name returns the name of the mutator.
+func (m *StatementRemovalMutator) Name() string {
+	return statementRemovalMutatorName
+}
+
+// CanMutate returns true if the node can be mutated by this mutator.
+func (m *StatementRemovalMutator) CanMutate(node ast.Node) bool {
+	return isRemovableStatement(node)
+}
+
+// Mutate generates mutants for the given node.
+func (m *StatementRemovalMutator) Mutate(node ast.Node, fset *token.FileSet) []Mutant {
+	if !isRemovableStatement(node) {
+		return nil
+	}
+
+	pos := fset.Position(node.Pos())
+
+	return []Mutant{
+		{
+			Line:        pos.Line,
+			Column:      pos.Column,
+			Type:        statementRemovalType,
+			Original:    stmtToString(node),
+			Mutated:     statementRemovalMutated,
+			Description: "Remove statement",
+		},
+	}
+}
+
+// Apply applies the mutation to the given AST node.
+// Statement removal requires node replacement via the cursor, so the plain
+// Apply path always reports failure.
+func (m *StatementRemovalMutator) Apply(_ ast.Node, _ Mutant) bool {
+	return false
+}
+
+// ApplyWithCursor removes the statement by replacing it with an empty statement.
+func (m *StatementRemovalMutator) ApplyWithCursor(node ast.Node, replaceFunc func(ast.Node), mutant Mutant) bool {
+	if mutant.Type != statementRemovalType {
+		return false
+	}
+
+	if !isRemovableStatement(node) {
+		return false
+	}
+
+	replaceFunc(&ast.EmptyStmt{})
+
+	return true
+}
+
+// isRemovableStatement reports whether node is a statement kind handled by this
+// mutator. AssignStmt and ExprStmt are intentionally excluded (handled by the
+// assignment_removal and expression_removal mutators respectively).
+func isRemovableStatement(node ast.Node) bool {
+	switch node.(type) {
+	case *ast.IncDecStmt, *ast.DeferStmt, *ast.GoStmt, *ast.SendStmt:
+		return true
+	default:
+		return false
+	}
+}
+
+// stmtToString renders a statement node to its source representation.
+func stmtToString(node ast.Node) string {
+	var buf strings.Builder
+
+	printer.Fprint(&buf, token.NewFileSet(), node) //nolint:errcheck
+
+	return buf.String()
+}

--- a/internal/mutation/statementremoval_test.go
+++ b/internal/mutation/statementremoval_test.go
@@ -1,0 +1,278 @@
+package mutation
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+func parseStmt(t *testing.T, fset *token.FileSet, code string) ast.Node {
+	t.Helper()
+
+	src := "package main\nfunc test() {\n\t" + code + "\n}"
+
+	file, err := parser.ParseFile(fset, "test.go", src, 0)
+	if err != nil {
+		t.Fatalf("Failed to parse file: %v", err)
+	}
+
+	var stmt ast.Node
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		switch n.(type) {
+		case *ast.IncDecStmt, *ast.DeferStmt, *ast.GoStmt, *ast.SendStmt:
+			stmt = n
+
+			return false
+		}
+
+		return true
+	})
+
+	if stmt == nil {
+		t.Fatalf("removable statement not found in: %s", code)
+	}
+
+	return stmt
+}
+
+func TestStatementRemovalMutator_Name(t *testing.T) {
+	t.Parallel()
+
+	mutator := &StatementRemovalMutator{}
+	if mutator.Name() != statementRemovalMutatorName {
+		t.Errorf("Expected name %q, got %s", statementRemovalMutatorName, mutator.Name())
+	}
+}
+
+func TestStatementRemovalMutator_CanMutate(t *testing.T) {
+	t.Parallel()
+
+	mutator := &StatementRemovalMutator{}
+
+	tests := []struct {
+		name string
+		code string
+	}{
+		{name: "increment", code: "i++"},
+		{name: "decrement", code: "i--"},
+		{name: "defer", code: "defer f()"},
+		{name: "go", code: "go f()"},
+		{name: "send", code: "ch <- 1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			fset := token.NewFileSet()
+			stmt := parseStmt(t, fset, tt.code)
+
+			if !mutator.CanMutate(stmt) {
+				t.Errorf("CanMutate() = false, want true for %s", tt.code)
+			}
+		})
+	}
+}
+
+func TestStatementRemovalMutator_CanMutate_Excluded(t *testing.T) {
+	t.Parallel()
+
+	mutator := &StatementRemovalMutator{}
+	fset := token.NewFileSet()
+
+	// Assignment and expression statements are handled by other mutators.
+	src := "package main\nfunc test() {\n\ta := 0\n\ta = 1\n\tf()\n}"
+
+	file, err := parser.ParseFile(fset, "test.go", src, 0)
+	if err != nil {
+		t.Fatalf("Failed to parse file: %v", err)
+	}
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		switch n.(type) {
+		case *ast.AssignStmt, *ast.ExprStmt:
+			if mutator.CanMutate(n) {
+				t.Errorf("CanMutate() = true, want false for %T", n)
+			}
+		}
+
+		return true
+	})
+}
+
+func TestStatementRemovalMutator_Mutate(t *testing.T) {
+	t.Parallel()
+
+	mutator := &StatementRemovalMutator{}
+
+	tests := []struct {
+		name         string
+		code         string
+		wantOriginal string
+	}{
+		{name: "increment", code: "i++", wantOriginal: "i++"},
+		{name: "defer", code: "defer f()", wantOriginal: "defer f()"},
+		{name: "go", code: "go f()", wantOriginal: "go f()"},
+		{name: "send", code: "ch <- 1", wantOriginal: "ch <- 1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			fset := token.NewFileSet()
+			stmt := parseStmt(t, fset, tt.code)
+
+			mutants := mutator.Mutate(stmt, fset)
+
+			if len(mutants) != 1 {
+				t.Fatalf("Expected 1 mutant, got %d", len(mutants))
+			}
+
+			m := mutants[0]
+
+			if m.Type != statementRemovalType {
+				t.Errorf("Type = %q, want %q", m.Type, statementRemovalType)
+			}
+
+			if m.Original != tt.wantOriginal {
+				t.Errorf("Original = %q, want %q", m.Original, tt.wantOriginal)
+			}
+
+			if m.Mutated != statementRemovalMutated {
+				t.Errorf("Mutated = %q, want %q", m.Mutated, statementRemovalMutated)
+			}
+
+			if m.Line <= 0 {
+				t.Errorf("Expected positive line number, got %d", m.Line)
+			}
+
+			if m.Description == "" {
+				t.Error("Expected non-empty description")
+			}
+		})
+	}
+}
+
+func TestStatementRemovalMutator_Mutate_NonRemovable(t *testing.T) {
+	t.Parallel()
+
+	mutator := &StatementRemovalMutator{}
+	fset := token.NewFileSet()
+
+	expr, err := parser.ParseExpr("a + b")
+	if err != nil {
+		t.Fatalf("Failed to parse expression: %v", err)
+	}
+
+	if mutants := mutator.Mutate(expr, fset); mutants != nil {
+		t.Errorf("Mutate() = %v, want nil for non-removable node", mutants)
+	}
+}
+
+func TestStatementRemovalMutator_Apply_AlwaysFalse(t *testing.T) {
+	t.Parallel()
+
+	mutator := &StatementRemovalMutator{}
+	fset := token.NewFileSet()
+	stmt := parseStmt(t, fset, "i++")
+
+	mutant := Mutant{Type: statementRemovalType, Original: "i++", Mutated: statementRemovalMutated}
+
+	if mutator.Apply(stmt, mutant) {
+		t.Error("Apply() = true, want false (removal requires cursor)")
+	}
+}
+
+func TestStatementRemovalMutator_ApplyWithCursor(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		code        string
+		mutantType  string
+		expected    bool
+		wantReplace bool
+	}{
+		{
+			name:        "removes increment statement",
+			code:        "i++",
+			mutantType:  statementRemovalType,
+			expected:    true,
+			wantReplace: true,
+		},
+		{
+			name:        "removes defer statement",
+			code:        "defer f()",
+			mutantType:  statementRemovalType,
+			expected:    true,
+			wantReplace: true,
+		},
+		{
+			name:        "wrong mutant type",
+			code:        "i++",
+			mutantType:  "unknown",
+			expected:    false,
+			wantReplace: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mutator := &StatementRemovalMutator{}
+			fset := token.NewFileSet()
+			stmt := parseStmt(t, fset, tt.code)
+
+			replaced := false
+
+			var replacement ast.Node
+
+			replaceFunc := func(n ast.Node) {
+				replaced = true
+				replacement = n
+			}
+
+			mutant := Mutant{Type: tt.mutantType, Original: tt.code, Mutated: statementRemovalMutated}
+
+			if result := mutator.ApplyWithCursor(stmt, replaceFunc, mutant); result != tt.expected {
+				t.Errorf("ApplyWithCursor() = %v, expected %v", result, tt.expected)
+			}
+
+			if replaced != tt.wantReplace {
+				t.Errorf("replaceFunc called = %v, want %v", replaced, tt.wantReplace)
+			}
+
+			if tt.wantReplace {
+				if _, ok := replacement.(*ast.EmptyStmt); !ok {
+					t.Errorf("replacement = %T, want *ast.EmptyStmt", replacement)
+				}
+			}
+		})
+	}
+}
+
+func TestStatementRemovalMutator_ApplyWithCursor_NonRemovable(t *testing.T) {
+	t.Parallel()
+
+	mutator := &StatementRemovalMutator{}
+
+	expr, err := parser.ParseExpr("a + b")
+	if err != nil {
+		t.Fatalf("Failed to parse expression: %v", err)
+	}
+
+	called := false
+	mutant := Mutant{Type: statementRemovalType, Original: "i++", Mutated: statementRemovalMutated}
+
+	if mutator.ApplyWithCursor(expr, func(ast.Node) { called = true }, mutant) {
+		t.Error("ApplyWithCursor() = true, want false for non-removable node")
+	}
+
+	if called {
+		t.Error("replaceFunc should not be called for non-removable node")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `StatementRemovalMutator` that removes statements carrying a side effect by replacing them with an empty statement
- Covers increment/decrement (`i++`, `i--`), `defer`, `go`, and channel send (`ch <- v`)
- Uses the `CursorApplier` interface for node replacement

## Disambiguation from related issues
One of three statement-removal operators, partitioned by node type to avoid duplicate mutants:
- #19 removes `*ast.AssignStmt`
- #20 removes `*ast.ExprStmt`
- #6 (this PR) removes the remaining removable statements: `*ast.IncDecStmt`, `*ast.DeferStmt`, `*ast.GoStmt`, `*ast.SendStmt`

`AssignStmt` and `ExprStmt` are explicitly excluded here so the three operators never target the same node.

## Changes
- `internal/mutation/statementremoval.go` — new mutator
- `internal/mutation/statementremoval_test.go` — unit tests (incl. `ApplyWithCursor`)
- `internal/mutation/registry.go` — regenerated (8 mutators)
- `internal/mutation/engine_test.go` — updated mutator count/list
- `internal/execution/overlay_test.go` + testdata — end-to-end golden test
- `README.md` — documented the new mutation type

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...`
- [x] `TestMutateAndApplyIntegration` covers removing `*counter++`
- [x] `make lint` (pinned golangci-lint) reports 0 issues

Closes #6
