### PR TITLE
feat: add `--list` and `--dry-run` flags to `gomu run`

### DIFF
--- a/cmd/gomu/main.go
+++ b/cmd/gomu/main.go
@@ -3,7 +3,9 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
+	"text/tabwriter"
 
 	"github.com/sivchari/gomu/pkg/gomu"
 	"github.com/spf13/cobra"
@@ -57,6 +59,7 @@ func init() {
 	rootCmd.AddCommand(versionCmd)
 
 	// Run command flags
+	runCmd.Flags().BoolP("list", "l", false, "list supported mutators and exit")
 	runCmd.Flags().Bool("ci-mode", false, "enable CI mode with quality gates and reporting")
 	runCmd.Flags().Float64("threshold", 80.0, "minimum mutation score threshold")
 	runCmd.Flags().String("output", "console", "output format (console, json, html, text)")
@@ -68,6 +71,12 @@ func init() {
 }
 
 func runMutationTesting(cmd *cobra.Command, args []string) error {
+	// --list is informational only: print the supported mutators and exit
+	// without discovering files or running any mutation.
+	if list, _ := cmd.Flags().GetBool("list"); list {
+		return listMutators(cmd.OutOrStdout())
+	}
+
 	path := "."
 	if len(args) > 0 {
 		path = args[0]
@@ -121,6 +130,25 @@ func runMutationTesting(cmd *cobra.Command, args []string) error {
 
 	if err := engine.Run(cmd.Context(), path, opts); err != nil {
 		return fmt.Errorf("mutation testing failed: %w", err)
+	}
+
+	return nil
+}
+
+// listMutators writes the catalog of supported mutators, one per line, with
+// names and descriptions aligned into columns.
+func listMutators(w io.Writer) error {
+	mutators := gomu.SupportedMutators()
+
+	fmt.Fprintf(w, "Supported mutators (%d):\n", len(mutators))
+
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	for _, m := range mutators {
+		fmt.Fprintf(tw, "  %s\t%s\n", m.Name, m.Description)
+	}
+
+	if err := tw.Flush(); err != nil {
+		return fmt.Errorf("failed to write mutator list: %w", err)
 	}
 
 	return nil

--- a/cmd/gomu/main.go
+++ b/cmd/gomu/main.go
@@ -60,6 +60,7 @@ func init() {
 
 	// Run command flags
 	runCmd.Flags().BoolP("list", "l", false, "list supported mutators and exit")
+	runCmd.Flags().Bool("dry-run", false, "show which mutations would run per file, without executing them")
 	runCmd.Flags().Bool("ci-mode", false, "enable CI mode with quality gates and reporting")
 	runCmd.Flags().Float64("threshold", 80.0, "minimum mutation score threshold")
 	runCmd.Flags().String("output", "console", "output format (console, json, html, text)")
@@ -83,6 +84,7 @@ func runMutationTesting(cmd *cobra.Command, args []string) error {
 	}
 
 	// Read CLI flags
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
 	ciMode, _ := cmd.Flags().GetBool("ci-mode")
 	workers, _ := cmd.Flags().GetInt("workers")
 	timeout, _ := cmd.Flags().GetInt("timeout")
@@ -121,6 +123,7 @@ func runMutationTesting(cmd *cobra.Command, args []string) error {
 		FailOnGate:  failOnGate,
 		Verbose:     verbose,
 		CIMode:      ciMode,
+		DryRun:      dryRun,
 	}
 
 	engine, err := gomu.NewEngine(opts)

--- a/cmd/gomu/main_test.go
+++ b/cmd/gomu/main_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/sivchari/gomu/pkg/gomu"
+)
+
+func TestListMutators(t *testing.T) {
+	var buf bytes.Buffer
+	if err := listMutators(&buf); err != nil {
+		t.Fatalf("listMutators: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "Supported mutators") {
+		t.Errorf("output missing header:\n%s", out)
+	}
+
+	mutators := gomu.SupportedMutators()
+	if len(mutators) == 0 {
+		t.Fatal("no supported mutators reported")
+	}
+
+	for _, m := range mutators {
+		if !strings.Contains(out, m.Name) {
+			t.Errorf("output missing mutator name %q:\n%s", m.Name, out)
+		}
+
+		if !strings.Contains(out, m.Description) {
+			t.Errorf("output missing description %q:\n%s", m.Description, out)
+		}
+	}
+}

--- a/internal/mutation/arithmetic.go
+++ b/internal/mutation/arithmetic.go
@@ -23,6 +23,11 @@ func (m *ArithmeticMutator) Name() string {
 	return arithmeticMutatorName
 }
 
+// Description returns a human-readable summary of the mutator.
+func (m *ArithmeticMutator) Description() string {
+	return "Replace arithmetic operators (+, -, *, /, %)"
+}
+
 // CanMutate returns true if the node can be mutated by this mutator.
 func (m *ArithmeticMutator) CanMutate(node ast.Node) bool {
 	switch n := node.(type) {

--- a/internal/mutation/assignmentremoval.go
+++ b/internal/mutation/assignmentremoval.go
@@ -25,6 +25,11 @@ func (m *AssignmentRemovalMutator) Name() string {
 	return assignmentRemovalMutatorName
 }
 
+// Description returns a human-readable summary of the mutator.
+func (m *AssignmentRemovalMutator) Description() string {
+	return "Remove assignment statements"
+}
+
 // CanMutate returns true if the node can be mutated by this mutator.
 func (m *AssignmentRemovalMutator) CanMutate(node ast.Node) bool {
 	stmt, ok := node.(*ast.AssignStmt)

--- a/internal/mutation/bitwise.go
+++ b/internal/mutation/bitwise.go
@@ -21,6 +21,11 @@ func (m *BitwiseMutator) Name() string {
 	return bitwiseMutatorName
 }
 
+// Description returns a human-readable summary of the mutator.
+func (m *BitwiseMutator) Description() string {
+	return "Replace bitwise operators (&, |, ^, &^, <<, >>)"
+}
+
 // CanMutate returns true if the node can be mutated by this mutator.
 func (m *BitwiseMutator) CanMutate(node ast.Node) bool {
 	switch n := node.(type) {

--- a/internal/mutation/boundary.go
+++ b/internal/mutation/boundary.go
@@ -27,6 +27,11 @@ func (m *BoundaryValueMutator) Name() string {
 	return boundaryValueMutatorName
 }
 
+// Description returns a human-readable summary of the mutator.
+func (m *BoundaryValueMutator) Description() string {
+	return "Shift integer literals to boundary values (N-1, N+1)"
+}
+
 // CanMutate returns true if the node can be mutated by this mutator.
 func (m *BoundaryValueMutator) CanMutate(node ast.Node) bool {
 	lit, ok := node.(*ast.BasicLit)

--- a/internal/mutation/branch.go
+++ b/internal/mutation/branch.go
@@ -22,6 +22,11 @@ func (m *BranchMutator) Name() string {
 	return branchMutatorName
 }
 
+// Description returns a human-readable summary of the mutator.
+func (m *BranchMutator) Description() string {
+	return "Force if-statement conditions to true or false"
+}
+
 // CanMutate returns true if the node can be mutated by this mutator.
 func (m *BranchMutator) CanMutate(node ast.Node) bool {
 	stmt, ok := node.(*ast.IfStmt)

--- a/internal/mutation/breakcontinue.go
+++ b/internal/mutation/breakcontinue.go
@@ -20,6 +20,11 @@ func (m *BreakContinueMutator) Name() string {
 	return breakContinueMutatorName
 }
 
+// Description returns a human-readable summary of the mutator.
+func (m *BreakContinueMutator) Description() string {
+	return "Swap break and continue statements"
+}
+
 // CanMutate returns true if the node can be mutated by this mutator.
 func (m *BreakContinueMutator) CanMutate(node ast.Node) bool {
 	stmt, ok := node.(*ast.BranchStmt)

--- a/internal/mutation/conditional.go
+++ b/internal/mutation/conditional.go
@@ -17,6 +17,11 @@ func (m *ConditionalMutator) Name() string {
 	return conditionalMutatorName
 }
 
+// Description returns a human-readable summary of the mutator.
+func (m *ConditionalMutator) Description() string {
+	return "Replace comparison operators (==, !=, <, <=, >, >=)"
+}
+
 // CanMutate returns true if the node can be mutated by this mutator.
 func (m *ConditionalMutator) CanMutate(node ast.Node) bool {
 	if expr, ok := node.(*ast.BinaryExpr); ok {

--- a/internal/mutation/descriptions_test.go
+++ b/internal/mutation/descriptions_test.go
@@ -1,0 +1,33 @@
+package mutation
+
+import "testing"
+
+// TestSupportedMutators verifies the catalog exposed for listing is complete:
+// every registered mutator must report a unique, non-empty name and a non-empty
+// description. This guards against a newly added mutator forgetting to
+// implement Description().
+func TestSupportedMutators(t *testing.T) {
+	mutators := SupportedMutators()
+	if len(mutators) == 0 {
+		t.Fatal("SupportedMutators returned no mutators")
+	}
+
+	seen := make(map[string]bool, len(mutators))
+
+	for _, m := range mutators {
+		name := m.Name()
+		if name == "" {
+			t.Errorf("mutator %T has an empty Name()", m)
+		}
+
+		if m.Description() == "" {
+			t.Errorf("mutator %q (%T) has an empty Description()", name, m)
+		}
+
+		if seen[name] {
+			t.Errorf("duplicate mutator name %q", name)
+		}
+
+		seen[name] = true
+	}
+}

--- a/internal/mutation/emptyblock.go
+++ b/internal/mutation/emptyblock.go
@@ -23,6 +23,11 @@ func (m *EmptyBlockMutator) Name() string {
 	return emptyBlockMutatorName
 }
 
+// Description returns a human-readable summary of the mutator.
+func (m *EmptyBlockMutator) Description() string {
+	return "Remove all statements from a block body"
+}
+
 // CanMutate returns true if the node can be mutated by this mutator.
 func (m *EmptyBlockMutator) CanMutate(node ast.Node) bool {
 	block, ok := node.(*ast.BlockStmt)

--- a/internal/mutation/engine.go
+++ b/internal/mutation/engine.go
@@ -70,6 +70,7 @@ const (
 // Mutator interface for different types of mutations.
 type Mutator interface {
 	Name() string
+	Description() string
 	CanMutate(node ast.Node) bool
 	Mutate(node ast.Node, fset *token.FileSet) []Mutant
 	Apply(node ast.Node, mutant Mutant) bool
@@ -157,4 +158,11 @@ func (e *Engine) GetFileSet() *token.FileSet {
 // GetMutators returns all mutators in the engine.
 func (e *Engine) GetMutators() []Mutator {
 	return e.mutators
+}
+
+// SupportedMutators returns every registered mutator without requiring a full
+// engine (no analyzer is constructed), making it suitable for listing the
+// available mutators.
+func SupportedMutators() []Mutator {
+	return getAllMutators()
 }

--- a/internal/mutation/errorhandling.go
+++ b/internal/mutation/errorhandling.go
@@ -22,6 +22,11 @@ func (m *ErrorHandlingMutator) Name() string {
 	return errorHandlingMutatorName
 }
 
+// Description returns a human-readable summary of the mutator.
+func (m *ErrorHandlingMutator) Description() string {
+	return "Replace a returned err with nil"
+}
+
 // CanMutate returns true if the node is a return statement containing an err identifier.
 func (m *ErrorHandlingMutator) CanMutate(node ast.Node) bool {
 	stmt, ok := node.(*ast.ReturnStmt)

--- a/internal/mutation/expressionremoval.go
+++ b/internal/mutation/expressionremoval.go
@@ -23,6 +23,11 @@ func (m *ExpressionRemovalMutator) Name() string {
 	return expressionRemovalMutatorName
 }
 
+// Description returns a human-readable summary of the mutator.
+func (m *ExpressionRemovalMutator) Description() string {
+	return "Remove expression statements"
+}
+
 // CanMutate returns true if the node can be mutated by this mutator.
 func (m *ExpressionRemovalMutator) CanMutate(node ast.Node) bool {
 	_, ok := node.(*ast.ExprStmt)

--- a/internal/mutation/invertnegatives.go
+++ b/internal/mutation/invertnegatives.go
@@ -20,6 +20,11 @@ func (m *InvertNegativesMutator) Name() string {
 	return invertNegativesMutatorName
 }
 
+// Description returns a human-readable summary of the mutator.
+func (m *InvertNegativesMutator) Description() string {
+	return "Replace unary minus with unary plus"
+}
+
 // CanMutate returns true if the node can be mutated by this mutator.
 func (m *InvertNegativesMutator) CanMutate(node ast.Node) bool {
 	if n, ok := node.(*ast.UnaryExpr); ok {

--- a/internal/mutation/logical.go
+++ b/internal/mutation/logical.go
@@ -21,6 +21,11 @@ func (m *LogicalMutator) Name() string {
 	return logicalMutatorName
 }
 
+// Description returns a human-readable summary of the mutator.
+func (m *LogicalMutator) Description() string {
+	return "Replace logical operators (&&, ||) and remove negation (!)"
+}
+
 // CanMutate returns true if the node can be mutated by this mutator.
 func (m *LogicalMutator) CanMutate(node ast.Node) bool {
 	if n, ok := node.(*ast.BinaryExpr); ok {

--- a/internal/mutation/loopcondition.go
+++ b/internal/mutation/loopcondition.go
@@ -22,6 +22,11 @@ func (m *LoopConditionMutator) Name() string {
 	return loopConditionMutatorName
 }
 
+// Description returns a human-readable summary of the mutator.
+func (m *LoopConditionMutator) Description() string {
+	return "Force for-loop conditions to true or false"
+}
+
 // CanMutate returns true if the node can be mutated by this mutator.
 func (m *LoopConditionMutator) CanMutate(node ast.Node) bool {
 	stmt, ok := node.(*ast.ForStmt)

--- a/internal/mutation/removeselfassignments.go
+++ b/internal/mutation/removeselfassignments.go
@@ -21,6 +21,11 @@ func (m *RemoveSelfAssignmentsMutator) Name() string {
 	return removeSelfAssignmentsMutatorName
 }
 
+// Description returns a human-readable summary of the mutator.
+func (m *RemoveSelfAssignmentsMutator) Description() string {
+	return "Replace compound assignment (e.g. +=) with plain ="
+}
+
 // CanMutate returns true if the node can be mutated by this mutator.
 func (m *RemoveSelfAssignmentsMutator) CanMutate(node ast.Node) bool {
 	if n, ok := node.(*ast.AssignStmt); ok {

--- a/internal/mutation/return.go
+++ b/internal/mutation/return.go
@@ -23,6 +23,11 @@ func (m *ReturnMutator) Name() string {
 	return returnMutatorName
 }
 
+// Description returns a human-readable summary of the mutator.
+func (m *ReturnMutator) Description() string {
+	return "Replace return values (flip bools, zero out literals)"
+}
+
 // CanMutate returns true if the node can be mutated by this mutator.
 func (m *ReturnMutator) CanMutate(node ast.Node) bool {
 	stmt, ok := node.(*ast.ReturnStmt)

--- a/internal/mutation/statementremoval.go
+++ b/internal/mutation/statementremoval.go
@@ -29,6 +29,11 @@ func (m *StatementRemovalMutator) Name() string {
 	return statementRemovalMutatorName
 }
 
+// Description returns a human-readable summary of the mutator.
+func (m *StatementRemovalMutator) Description() string {
+	return "Remove statements (inc/dec, defer, go, channel send)"
+}
+
 // CanMutate returns true if the node can be mutated by this mutator.
 func (m *StatementRemovalMutator) CanMutate(node ast.Node) bool {
 	return isRemovableStatement(node)

--- a/internal/mutation/stringliteral.go
+++ b/internal/mutation/stringliteral.go
@@ -29,6 +29,11 @@ func (m *StringLiteralMutator) Name() string {
 	return stringLiteralMutatorName
 }
 
+// Description returns a human-readable summary of the mutator.
+func (m *StringLiteralMutator) Description() string {
+	return "Swap string literals between empty and non-empty"
+}
+
 // CanMutate returns true if the node can be mutated by this mutator.
 func (m *StringLiteralMutator) CanMutate(node ast.Node) bool {
 	lit, ok := node.(*ast.BasicLit)

--- a/pkg/gomu/catalog_test.go
+++ b/pkg/gomu/catalog_test.go
@@ -1,0 +1,21 @@
+package gomu
+
+import (
+	"testing"
+
+	"github.com/sivchari/gomu/internal/mutation"
+)
+
+func TestSupportedMutators(t *testing.T) {
+	infos := SupportedMutators()
+
+	if want := len(mutation.SupportedMutators()); len(infos) != want {
+		t.Fatalf("expected %d mutators, got %d", want, len(infos))
+	}
+
+	for _, info := range infos {
+		if info.Name == "" || info.Description == "" {
+			t.Errorf("incomplete mutator info: %+v", info)
+		}
+	}
+}

--- a/pkg/gomu/dryrun_test.go
+++ b/pkg/gomu/dryrun_test.go
@@ -1,0 +1,137 @@
+package gomu
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sivchari/gomu/internal/mutation"
+)
+
+func TestWriteDryRunFile(t *testing.T) {
+	var buf bytes.Buffer
+
+	mutants := []mutation.Mutant{
+		{Line: 12, Column: 7, Type: "arithmetic_binary", Description: "Replace + with -"},
+		{Line: 20, Column: 3, Type: "conditional_binary", Description: "Replace < with <="},
+	}
+
+	writeDryRunFile(&buf, "foo.go", mutants)
+
+	out := buf.String()
+	for _, want := range []string{
+		"foo.go (2 mutants)",
+		"L12:7", "arithmetic_binary", "Replace + with -",
+		"L20:3", "conditional_binary", "Replace < with <=",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("dry-run output missing %q\n%s", want, out)
+		}
+	}
+}
+
+func TestDryRunNoFiles(t *testing.T) {
+	engine, err := NewEngine(nil)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := engine.dryRun(&buf, nil); err != nil {
+		t.Fatalf("dryRun: %v", err)
+	}
+
+	if !strings.Contains(buf.String(), "no files to analyze") {
+		t.Errorf("unexpected output for empty file list: %q", buf.String())
+	}
+}
+
+func TestDryRunGeneratesMutants(t *testing.T) {
+	tempDir := t.TempDir()
+	writeFile(t, filepath.Join(tempDir, "go.mod"), testModuleContent)
+
+	file := filepath.Join(tempDir, "math.go")
+	writeFile(t, file, `package main
+
+func Add(a, b int) int {
+	return a + b
+}
+`)
+
+	engine, err := NewEngine(nil)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := engine.dryRun(&buf, []string{file}); err != nil {
+		t.Fatalf("dryRun: %v", err)
+	}
+
+	out := buf.String()
+	for _, want := range []string{"math.go", "Total:", "arithmetic"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("dry-run output missing %q\n%s", want, out)
+		}
+	}
+}
+
+// TestRunDryRunSkipsExecution proves the dry-run path stops before execution and
+// reporting: with JSON output configured, a real run would write
+// mutation-report.json, but a dry run must not.
+func TestRunDryRunSkipsExecution(t *testing.T) {
+	tempDir := t.TempDir()
+	writeFile(t, filepath.Join(tempDir, "go.mod"), testModuleContent)
+	writeFile(t, filepath.Join(tempDir, "math.go"), `package main
+
+func Add(a, b int) int {
+	return a + b
+}
+`)
+
+	// Reports and history are written relative to the working directory; run
+	// inside the isolated temp dir so any side effects are contained and
+	// observable.
+	origWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	defer func() {
+		if err := os.Chdir(origWD); err != nil {
+			t.Fatalf("restore wd: %v", err)
+		}
+	}()
+
+	opts := &RunOptions{DryRun: true, Incremental: false, Output: "json", Workers: 1, Timeout: 5}
+
+	engine, err := NewEngine(opts)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+
+	if err := engine.Run(context.Background(), ".", opts); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	for _, name := range []string{"mutation-report.json", ".gomu_history.json"} {
+		if _, err := os.Stat(filepath.Join(tempDir, name)); !os.IsNotExist(err) {
+			t.Errorf("dry run should not create %s", name)
+		}
+	}
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/pkg/gomu/engine.go
+++ b/pkg/gomu/engine.go
@@ -427,13 +427,22 @@ func (e *Engine) dryRun(w io.Writer, files []string) error {
 
 	fmt.Fprintf(w, "Dry run: analyzing %d file(s) (no mutations will be executed)\n", len(files))
 
+	// Discovered files are absolute (derived from the resolved target path);
+	// display them relative to the working directory.
+	wd, wdErr := os.Getwd()
+	if wdErr != nil {
+		wd = ""
+	}
+
 	totalMutants := 0
 	filesWithMutants := 0
 
 	for _, file := range files {
 		mutants, err := e.mutator.GenerateMutants(file)
+		displayPath := analysis.GetRelativePath(wd, file)
+
 		if err != nil {
-			fmt.Fprintf(w, "\n%s (error: %v)\n", file, err)
+			fmt.Fprintf(w, "\n%s (error: %v)\n", displayPath, err)
 
 			continue
 		}
@@ -445,7 +454,7 @@ func (e *Engine) dryRun(w io.Writer, files []string) error {
 		filesWithMutants++
 		totalMutants += len(mutants)
 
-		writeDryRunFile(w, file, mutants)
+		writeDryRunFile(w, displayPath, mutants)
 	}
 
 	fmt.Fprintf(w, "\nTotal: %d mutant(s) across %d file(s)\n", totalMutants, filesWithMutants)

--- a/pkg/gomu/engine.go
+++ b/pkg/gomu/engine.go
@@ -44,6 +44,26 @@ type RunOptions struct {
 	CIMode      bool
 }
 
+// MutatorInfo describes a single supported mutator for catalog/listing purposes.
+type MutatorInfo struct {
+	Name        string
+	Description string
+}
+
+// SupportedMutators returns the catalog of mutators gomu can apply. It does not
+// run any mutation and constructs no analyzer, so it is cheap to call for
+// listing purposes.
+func SupportedMutators() []MutatorInfo {
+	mutators := mutation.SupportedMutators()
+	infos := make([]MutatorInfo, len(mutators))
+
+	for i, m := range mutators {
+		infos[i] = MutatorInfo{Name: m.Name(), Description: m.Description()}
+	}
+
+	return infos
+}
+
 // NewEngine creates a new mutation testing engine.
 func NewEngine(opts *RunOptions) (*Engine, error) {
 	// Create analyzer without ignore parser - it will be set later in Run

--- a/pkg/gomu/engine.go
+++ b/pkg/gomu/engine.go
@@ -4,9 +4,11 @@ package gomu
 import (
 	"context"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
+	"text/tabwriter"
 	"time"
 
 	"github.com/sivchari/gomu/internal/analysis"
@@ -42,6 +44,7 @@ type RunOptions struct {
 	FailOnGate  bool
 	Verbose     bool
 	CIMode      bool
+	DryRun      bool // Discover mutants per file without executing any mutation
 }
 
 // MutatorInfo describes a single supported mutator for catalog/listing purposes.
@@ -285,6 +288,12 @@ func (e *Engine) Run(ctx context.Context, path string, opts *RunOptions) error {
 		return err
 	}
 
+	// Dry run stops after discovery: report the mutants that would be generated
+	// per file without applying any mutation, running tests, or reporting.
+	if opts.DryRun {
+		return e.dryRun(os.Stdout, files)
+	}
+
 	if len(files) == 0 {
 		if opts.Verbose {
 			log.Println("No files need processing - all files are up to date")
@@ -405,6 +414,55 @@ func (e *Engine) processFiles(files []string, opts *RunOptions) ([]mutation.Resu
 	}
 
 	return allResults, totalMutants, processedFiles
+}
+
+// dryRun reports the mutants that would be generated for each file without
+// applying any mutation, running any tests, or producing reports.
+func (e *Engine) dryRun(w io.Writer, files []string) error {
+	if len(files) == 0 {
+		fmt.Fprintln(w, "Dry run: no files to analyze")
+
+		return nil
+	}
+
+	fmt.Fprintf(w, "Dry run: analyzing %d file(s) (no mutations will be executed)\n", len(files))
+
+	totalMutants := 0
+	filesWithMutants := 0
+
+	for _, file := range files {
+		mutants, err := e.mutator.GenerateMutants(file)
+		if err != nil {
+			fmt.Fprintf(w, "\n%s (error: %v)\n", file, err)
+
+			continue
+		}
+
+		if len(mutants) == 0 {
+			continue
+		}
+
+		filesWithMutants++
+		totalMutants += len(mutants)
+
+		writeDryRunFile(w, file, mutants)
+	}
+
+	fmt.Fprintf(w, "\nTotal: %d mutant(s) across %d file(s)\n", totalMutants, filesWithMutants)
+
+	return nil
+}
+
+// writeDryRunFile renders a file's discovered mutants as an aligned table.
+func writeDryRunFile(w io.Writer, file string, mutants []mutation.Mutant) {
+	fmt.Fprintf(w, "\n%s (%d mutants)\n", file, len(mutants))
+
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	for _, m := range mutants {
+		fmt.Fprintf(tw, "  L%d:%d\t%s\t%s\n", m.Line, m.Column, m.Type, m.Description)
+	}
+
+	tw.Flush() //nolint:errcheck // writing to caller-provided writer
 }
 
 // cleanupAndSave handles cleanup and saving operations.


### PR DESCRIPTION
## Summary

Adds two discovery-only flags to `gomu run`, implementing #90. Both stop short of the execution phase, so they are fast and side-effect-free.

### `-l, --list`
Prints the catalog of supported mutators with one-line descriptions and exits — no path, no AST walk, no mutation.

```
$ gomu run --list
Supported mutators (17):
  arithmetic          Replace arithmetic operators (+, -, *, /, %)
  conditional         Replace comparison operators (==, !=, <, <=, >, >=)
  ...
```

### `--dry-run`
Runs the real file-selection and mutant-generation pipeline and prints which mutations would run per file, but executes nothing (no overlay build, no `go test`, no report, no CI gate). It honors `--incremental`, so it reflects exactly what a real run would process; `--incremental=false` previews every file.

```
$ gomu run --dry-run ./...
Dry run: analyzing 2 file(s) (no mutations will be executed)

pkg/foo/foo.go (3 mutants)
  L12:7  arithmetic_binary  Replace + with -
  ...

Total: 3 mutant(s) across 1 file(s)
```

## Implementation

Respects the existing `cmd/gomu → pkg/gomu → internal/mutation` layering.

- **internal/mutation**: adds `Description()` to the `Mutator` interface (implemented by every mutator) and an exported `SupportedMutators()` that returns the registry without constructing an analyzer. No new mutator structs, so `registry.go` and its generator are untouched (`go generate` is a no-op).
- **pkg/gomu**: adds public `MutatorInfo` + `SupportedMutators()`; adds a `DryRun` option; `Run()` branches to an `io.Writer`-based dry-run formatter right after file discovery, before any execution or reporting.
- **cmd/gomu**: registers `--list`/`-l` and `--dry-run` on the run command; `--list` is handled first via `listMutators` using `text/tabwriter` for alignment.

## Tests

- every mutator reports a unique, non-empty `Name()` / `Description()`
- dry-run formatter output, the `SupportedMutators()` mapping, and an end-to-end `Run(DryRun)` test asserting no report or history file is produced
- `listMutators` output

## Verification

`go build ./...`, `go vet ./...`, `go test ./...` pass; `go generate ./internal/mutation` leaves `registry.go` unchanged.
