### PR TITLE
fix: address PR #91 code review findings for --list/--dry-run

### DIFF
--- a/cmd/gomu/main.go
+++ b/cmd/gomu/main.go
@@ -147,6 +147,7 @@ func warnIgnoredFlags(cmd *cobra.Command) {
 	ignorable := []string{"dry-run", "ci-mode", "threshold", "output", "fail-on-gate", "workers", "timeout", "incremental", "base-branch"}
 
 	var ignored []string
+
 	for _, name := range ignorable {
 		if cmd.Flags().Changed(name) {
 			ignored = append(ignored, "--"+name)

--- a/cmd/gomu/main.go
+++ b/cmd/gomu/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/sivchari/gomu/pkg/gomu"
@@ -75,6 +76,8 @@ func runMutationTesting(cmd *cobra.Command, args []string) error {
 	// --list is informational only: print the supported mutators and exit
 	// without discovering files or running any mutation.
 	if list, _ := cmd.Flags().GetBool("list"); list {
+		warnIgnoredFlags(cmd)
+
 		return listMutators(cmd.OutOrStdout())
 	}
 
@@ -136,6 +139,23 @@ func runMutationTesting(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+// warnIgnoredFlags warns on stderr about flags the user explicitly set that
+// --list ignores, since --list exits before those flags take effect.
+func warnIgnoredFlags(cmd *cobra.Command) {
+	ignorable := []string{"dry-run", "ci-mode", "threshold", "output", "fail-on-gate", "workers", "timeout", "incremental", "base-branch"}
+
+	var ignored []string
+	for _, name := range ignorable {
+		if cmd.Flags().Changed(name) {
+			ignored = append(ignored, "--"+name)
+		}
+	}
+
+	if len(ignored) > 0 {
+		fmt.Fprintf(cmd.ErrOrStderr(), "Warning: --list ignores %s\n", strings.Join(ignored, ", "))
+	}
 }
 
 // listMutators writes the catalog of supported mutators, one per line, with

--- a/cmd/gomu/main_test.go
+++ b/cmd/gomu/main_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/sivchari/gomu/pkg/gomu"
+	"github.com/spf13/pflag"
 )
 
 func TestListMutators(t *testing.T) {
@@ -32,5 +33,58 @@ func TestListMutators(t *testing.T) {
 		if !strings.Contains(out, m.Description) {
 			t.Errorf("output missing description %q:\n%s", m.Description, out)
 		}
+	}
+}
+
+func TestRunListWarnsIgnoredFlags(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		wantWarning bool
+	}{
+		{
+			name:        "list alone produces no warning",
+			args:        []string{"run", "--list"},
+			wantWarning: false,
+		},
+		{
+			name:        "list with output warns about ignored flag",
+			args:        []string{"run", "--list", "--output", "json"},
+			wantWarning: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+
+			rootCmd.SetArgs(tt.args)
+			rootCmd.SetOut(&stdout)
+			rootCmd.SetErr(&stderr)
+
+			if err := rootCmd.Execute(); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+
+			errOut := stderr.String()
+
+			if tt.wantWarning {
+				if !strings.Contains(errOut, "--output") {
+					t.Errorf("expected warning mentioning --output, got: %q", errOut)
+				}
+			} else if errOut != "" {
+				t.Errorf("expected no warning, got: %q", errOut)
+			}
+
+			// Reset flags for subsequent test cases since runCmd is a
+			// package-level var shared across tests.
+			if err := runCmd.Flags().Set("output", "console"); err != nil {
+				t.Fatalf("reset output flag: %v", err)
+			}
+
+			runCmd.Flags().Visit(func(f *pflag.Flag) {
+				f.Changed = false
+			})
+		})
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,9 @@ go 1.24
 require (
 	github.com/google/go-cmp v0.7.0
 	github.com/spf13/cobra v1.8.0
+	github.com/spf13/pflag v1.0.5
 	golang.org/x/text v0.27.0
 	golang.org/x/tools v0.34.0
 )
 
-require (
-	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
-)
+require github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/pkg/gomu/dryrun_test.go
+++ b/pkg/gomu/dryrun_test.go
@@ -19,7 +19,9 @@ func TestWriteDryRunFile(t *testing.T) {
 		{Line: 20, Column: 3, Type: "conditional_binary", Description: "Replace < with <="},
 	}
 
-	writeDryRunFile(&buf, "foo.go", mutants)
+	if err := writeDryRunFile(&buf, "foo.go", mutants); err != nil {
+		t.Fatalf("writeDryRunFile: %v", err)
+	}
 
 	out := buf.String()
 	for _, want := range []string{
@@ -39,14 +41,41 @@ func TestDryRunNoFiles(t *testing.T) {
 		t.Fatalf("NewEngine: %v", err)
 	}
 
-	var buf bytes.Buffer
-	if err := engine.dryRun(&buf, nil); err != nil {
-		t.Fatalf("dryRun: %v", err)
-	}
+	t.Run("incremental", func(t *testing.T) {
+		var buf bytes.Buffer
 
-	if !strings.Contains(buf.String(), "no files to analyze") {
-		t.Errorf("unexpected output for empty file list: %q", buf.String())
-	}
+		opts := &RunOptions{Incremental: true, BaseBranch: "main"}
+		if err := engine.dryRun(&buf, nil, opts); err != nil {
+			t.Fatalf("dryRun: %v", err)
+		}
+
+		out := buf.String()
+		for _, want := range []string{"no files to analyze", "main", "--incremental=false"} {
+			if !strings.Contains(out, want) {
+				t.Errorf("output missing %q: %q", want, out)
+			}
+		}
+	})
+
+	t.Run("non-incremental", func(t *testing.T) {
+		var buf bytes.Buffer
+
+		opts := &RunOptions{Incremental: false}
+		if err := engine.dryRun(&buf, nil, opts); err != nil {
+			t.Fatalf("dryRun: %v", err)
+		}
+
+		out := buf.String()
+		if !strings.Contains(out, "no files to analyze") {
+			t.Errorf("unexpected output for empty file list: %q", out)
+		}
+
+		for _, unwanted := range []string{"main", "--incremental=false"} {
+			if strings.Contains(out, unwanted) {
+				t.Errorf("output should not contain %q: %q", unwanted, out)
+			}
+		}
+	})
 }
 
 func TestDryRunGeneratesMutants(t *testing.T) {
@@ -67,7 +96,7 @@ func Add(a, b int) int {
 	}
 
 	var buf bytes.Buffer
-	if err := engine.dryRun(&buf, []string{file}); err != nil {
+	if err := engine.dryRun(&buf, []string{file}, &RunOptions{}); err != nil {
 		t.Fatalf("dryRun: %v", err)
 	}
 

--- a/pkg/gomu/engine.go
+++ b/pkg/gomu/engine.go
@@ -291,7 +291,7 @@ func (e *Engine) Run(ctx context.Context, path string, opts *RunOptions) error {
 	// Dry run stops after discovery: report the mutants that would be generated
 	// per file without applying any mutation, running tests, or reporting.
 	if opts.DryRun {
-		return e.dryRun(os.Stdout, files)
+		return e.dryRun(os.Stdout, files, opts)
 	}
 
 	if len(files) == 0 {
@@ -418,9 +418,13 @@ func (e *Engine) processFiles(files []string, opts *RunOptions) ([]mutation.Resu
 
 // dryRun reports the mutants that would be generated for each file without
 // applying any mutation, running any tests, or producing reports.
-func (e *Engine) dryRun(w io.Writer, files []string) error {
+func (e *Engine) dryRun(w io.Writer, files []string, opts *RunOptions) error {
 	if len(files) == 0 {
-		fmt.Fprintln(w, "Dry run: no files to analyze")
+		if opts.Incremental {
+			fmt.Fprintf(w, "Dry run: no files to analyze (no changes since %s; use --incremental=false to preview all files)\n", opts.BaseBranch)
+		} else {
+			fmt.Fprintln(w, "Dry run: no files to analyze")
+		}
 
 		return nil
 	}
@@ -454,7 +458,9 @@ func (e *Engine) dryRun(w io.Writer, files []string) error {
 		filesWithMutants++
 		totalMutants += len(mutants)
 
-		writeDryRunFile(w, displayPath, mutants)
+		if err := writeDryRunFile(w, displayPath, mutants); err != nil {
+			return err
+		}
 	}
 
 	fmt.Fprintf(w, "\nTotal: %d mutant(s) across %d file(s)\n", totalMutants, filesWithMutants)
@@ -463,7 +469,7 @@ func (e *Engine) dryRun(w io.Writer, files []string) error {
 }
 
 // writeDryRunFile renders a file's discovered mutants as an aligned table.
-func writeDryRunFile(w io.Writer, file string, mutants []mutation.Mutant) {
+func writeDryRunFile(w io.Writer, file string, mutants []mutation.Mutant) error {
 	fmt.Fprintf(w, "\n%s (%d mutants)\n", file, len(mutants))
 
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
@@ -471,7 +477,11 @@ func writeDryRunFile(w io.Writer, file string, mutants []mutation.Mutant) {
 		fmt.Fprintf(tw, "  L%d:%d\t%s\t%s\n", m.Line, m.Column, m.Type, m.Description)
 	}
 
-	tw.Flush() //nolint:errcheck // writing to caller-provided writer
+	if err := tw.Flush(); err != nil {
+		return fmt.Errorf("failed to write mutant table: %w", err)
+	}
+
+	return nil
 }
 
 // cleanupAndSave handles cleanup and saving operations.


### PR DESCRIPTION
## Summary
Follow-up fixes for issues found in review of #91 (already merged):
- `writeDryRunFile` no longer swallows the tabwriter `Flush()` error via `nolint`; it now returns and propagates it.
- `--dry-run` now hints that an empty result may be due to the `--incremental` filter (default true), suggesting `--incremental=false`.
- `gomu run --list` now warns on stderr when combined with other run flags (e.g. `--output`) that it silently ignores.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go test ./...`